### PR TITLE
docs(readme): add withdraw, broadcast, shared visibility, and agent webhook setup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { validateApiKey, getAccountsByService, getCookieSecret, getSetting, getMessagingMode } from './lib/db.js';
+import { validateApiKey, getAccountsByService, getCookieSecret, getMessagingMode } from './lib/db.js';
 import { connectHsync } from './lib/hsyncManager.js';
 import { initSocket } from './lib/socketManager.js';
 import githubRoutes, { serviceInfo as githubInfo } from './routes/github.js';


### PR DESCRIPTION
## Summary

Updates `/api/readme` to document features from recent PRs (#20, #22, #24, #26):

### writeQueue
- **withdraw endpoint**: `DELETE /api/queue/{service}/{account}/status/{id}`
- **withdrawn status**: Added to statuses list
- **shared_visibility**: Added to listMyRequests response
- **submitted_by**: Added to list response

### agentMessaging
- **broadcast endpoint**: `POST /api/agents/broadcast`

### notifications (rewritten)
- **Per-agent webhook setup**: Explains API Keys → Configure
- **Gateway config required**: Notes that `hooks.enabled` must be set on receiving gateway
- **Troubleshooting tips**: Common issues and how to test
- **All event types**: completed, failed, rejected, agent_message, broadcast, message_rejected

## Why

Pippin hit the webhook config issue (had agentgate webhook set but not `hooks.enabled` in her gateway). This update makes the two-sided setup clearer.

## Related
- #20 - shared queue visibility + agent withdraw
- #22 - withdraw endpoint bug fixes
- #24 - broadcast
- #26 - webhook troubleshooting docs