### PR TITLE
fix(ui): add full nav header to ALL sub-pages

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -1153,10 +1153,24 @@ function renderQueuePage(entries, filter, counts = 0) {
   </style>
 </head>
 <body>
-  <div style="display: flex; justify-content: space-between; align-items: center;">
-    <h1>Write Queue</h1>
-    <a href="/ui" class="back-link">&larr; Back to Dashboard</a>
+  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <a href="/ui" style="display: flex; align-items: center; gap: 12px; text-decoration: none; color: inherit;">
+        <img src="/public/favicon.svg" alt="agentgate" style="height: 48px;">
+        <h1 style="margin: 0;">agentgate</h1>
+      </a>
+    </div>
+    <div style="display: flex; gap: 12px; align-items: center;">
+      <a href="/ui/keys" class="nav-btn nav-btn-default">Agents</a>
+      <a href="/ui/queue" class="nav-btn nav-btn-default">Write Queue</a>
+      <a href="/ui/messages" class="nav-btn nav-btn-default">Messages</a>
+      <div class="nav-divider"></div>
+      <form method="POST" action="/ui/logout" style="margin: 0;">
+        <button type="submit" class="nav-btn nav-btn-default" style="color: #f87171;">Logout</button>
+      </form>
+    </div>
   </div>
+  <h2 style="margin-top: 0;">Write Queue</h2>
   <p>Review and approve write requests from agents.</p>
 
   <div class="filter-bar" id="filter-bar">
@@ -1656,12 +1670,26 @@ function renderMessagesPage(messages, filter, counts, mode) {
   </style>
 </head>
 <body>
-  <div style="display: flex; justify-content: space-between; align-items: center;">
-    <h1>Agent Messages</h1>
-    <div style="display: flex; align-items: center; gap: 16px;">
-      <span class="mode-badge">Mode: ${mode}</span>
-      <a href="/ui" class="back-link">← Back to Dashboard</a>
+  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <a href="/ui" style="display: flex; align-items: center; gap: 12px; text-decoration: none; color: inherit;">
+        <img src="/public/favicon.svg" alt="agentgate" style="height: 48px;">
+        <h1 style="margin: 0;">agentgate</h1>
+      </a>
     </div>
+    <div style="display: flex; gap: 12px; align-items: center;">
+      <a href="/ui/keys" class="nav-btn nav-btn-default">Agents</a>
+      <a href="/ui/queue" class="nav-btn nav-btn-default">Write Queue</a>
+      <a href="/ui/messages" class="nav-btn nav-btn-default">Messages</a>
+      <div class="nav-divider"></div>
+      <form method="POST" action="/ui/logout" style="margin: 0;">
+        <button type="submit" class="nav-btn nav-btn-default" style="color: #f87171;">Logout</button>
+      </form>
+    </div>
+  </div>
+  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+    <h2 style="margin: 0;">Agent Messages</h2>
+    <span class="mode-badge">Mode: ${mode}</span>
   </div>
   <p>Review and approve messages between agents${mode === 'supervised' ? ' (supervised mode)' : ''}.</p>
 
@@ -1977,10 +2005,24 @@ function renderKeysPage(keys, error = null, newKey = null) {
   </style>
 </head>
 <body>
-  <div style="display: flex; justify-content: space-between; align-items: center;">
-    <h1>Agents</h1>
-    <a href="/ui" class="back-link">&larr; Back to Dashboard</a>
+  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <a href="/ui" style="display: flex; align-items: center; gap: 12px; text-decoration: none; color: inherit;">
+        <img src="/public/favicon.svg" alt="agentgate" style="height: 48px;">
+        <h1 style="margin: 0;">agentgate</h1>
+      </a>
+    </div>
+    <div style="display: flex; gap: 12px; align-items: center;">
+      <a href="/ui/keys" class="nav-btn nav-btn-default">Agents</a>
+      <a href="/ui/queue" class="nav-btn nav-btn-default">Write Queue</a>
+      <a href="/ui/messages" class="nav-btn nav-btn-default">Messages</a>
+      <div class="nav-divider"></div>
+      <form method="POST" action="/ui/logout" style="margin: 0;">
+        <button type="submit" class="nav-btn nav-btn-default" style="color: #f87171;">Logout</button>
+      </form>
+    </div>
   </div>
+  <h2 style="margin-top: 0;">Agents</h2>
   <p>Manage API keys for your agents. Keys are hashed and can only be viewed once at creation.</p>
 
   ${error ? `<div class="error-message">${escapeHtml(error)}</div>` : ''}


### PR DESCRIPTION
## Summary

Previous PR (#32) updated the new modular files but the app still uses the legacy `ui.js`. This PR updates the actual active code.

### Changes
- **Queue page** - Full nav header with logo + links
- **Messages page** - Full nav header (kept mode badge)
- **Agents page** - Full nav header

All sub-pages now have consistent navigation matching the dashboard.