### PR TITLE
fix: display dates in browser local timezone

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -675,6 +675,14 @@ function renderPage(accounts, { hsyncConfig, hsyncUrl, hsyncConnected, pendingQu
       socket.on('connect', function() {
         console.log('Socket.io connected for real-time updates');
       });
+
+      // Localize UTC dates to browser timezone
+      document.querySelectorAll('.utc-date').forEach(function(el) {
+        const utc = el.dataset.utc;
+        if (utc) {
+          el.textContent = new Date(utc).toLocaleString();
+        }
+      });
     });
   </script>
 </head>
@@ -899,6 +907,12 @@ function renderQueuePage(entries, filter, counts = 0, pendingQueueCount = 0, pen
     return d.toLocaleString();
   };
 
+  // Format date as span with data-utc for client-side localization
+  const localDate = (dateStr) => {
+    if (!dateStr) return '';
+    return `<span class="utc-date" data-utc="${dateStr}">${formatDate(dateStr)}</span>`;
+  };
+
   const renderEntry = (entry) => {
     const requestsSummary = entry.requests.map((r) =>
       `<div class="request-item"><code>${r.method}</code> <span>${escapeHtml(r.path)}</span></div>`
@@ -962,7 +976,7 @@ function renderQueuePage(entries, filter, counts = 0, pendingQueueCount = 0, pen
             <span class="status-badge">${statusBadge(entry.status)}</span>
           </div>
           <div style="display: flex; align-items: center; gap: 12px;">
-            <span class="help" style="margin: 0;">${formatDate(entry.submitted_at)}</span>
+            <span class="help" style="margin: 0;">${localDate(entry.submitted_at)}</span>
             <button type="button" class="delete-btn" onclick="deleteEntry('${entry.id}')" title="Delete">&times;</button>
           </div>
         </div>
@@ -1538,6 +1552,14 @@ function renderQueuePage(entries, filter, counts = 0, pendingQueueCount = 0, pen
           msgNav.style.display = data.messagingEnabled ? '' : 'none';
         }
       });
+
+      // Localize UTC dates to browser timezone
+      document.querySelectorAll('.utc-date').forEach(function(el) {
+        const utc = el.dataset.utc;
+        if (utc) {
+          el.textContent = new Date(utc).toLocaleString();
+        }
+      });
     });
   </script>
 </body>
@@ -1555,6 +1577,11 @@ function renderMessagesPage(messages, filter, counts, mode, pendingQueueCount = 
     if (!dateStr) return '';
     const d = new Date(dateStr);
     return d.toLocaleString();
+  };
+
+  const localDate = (dateStr) => {
+    if (!dateStr) return '';
+    return `<span class="utc-date" data-utc="${dateStr}">${formatDate(dateStr)}</span>`;
   };
 
   const statusBadge = (status) => {
@@ -1595,7 +1622,7 @@ function renderMessagesPage(messages, filter, counts, mode, pendingQueueCount = 
             <span class="status-badge">${statusBadge(msg.status)}</span>
           </div>
           <div style="display: flex; align-items: center; gap: 12px;">
-            <span class="help" style="margin: 0;">${formatDate(msg.created_at)}</span>
+            <span class="help" style="margin: 0;">${localDate(msg.created_at)}</span>
             <button type="button" class="delete-btn" onclick="deleteMessage('${msg.id}')" title="Delete">&times;</button>
           </div>
         </div>
@@ -2033,6 +2060,14 @@ function renderMessagesPage(messages, filter, counts, mode, pendingQueueCount = 
           msgNav.style.display = data.messagingEnabled ? '' : 'none';
         }
       });
+
+      // Localize UTC dates to browser timezone
+      document.querySelectorAll('.utc-date').forEach(function(el) {
+        const utc = el.dataset.utc;
+        if (utc) {
+          el.textContent = new Date(utc).toLocaleString();
+        }
+      });
     });
   </script>
 </body>
@@ -2051,6 +2086,11 @@ function renderKeysPage(keys, error = null, newKey = null, pendingQueueCount = 0
     return d.toLocaleString();
   };
 
+  const localDate = (dateStr) => {
+    if (!dateStr) return '';
+    return `<span class="utc-date" data-utc="${dateStr}">${formatDate(dateStr)}</span>`;
+  };
+
   const renderKeyRow = (k) => `
     <tr id="key-${k.id}">
       <td><strong>${escapeHtml(k.name)}</strong></td>
@@ -2063,7 +2103,7 @@ function renderKeysPage(keys, error = null, newKey = null, pendingQueueCount = 0
         `}
         <button type="button" class="btn-sm webhook-btn" data-id="${k.id}" data-name="${escapeHtml(k.name)}" data-url="${escapeHtml(k.webhook_url || '')}" data-token="${escapeHtml(k.webhook_token || '')}">Configure</button>
       </td>
-      <td>${formatDate(k.created_at)}</td>
+      <td>${localDate(k.created_at)}</td>
       <td>
         <button type="button" class="delete-btn" onclick="deleteKey('${k.id}')" title="Delete">&times;</button>
       </td>
@@ -2319,6 +2359,14 @@ function renderKeysPage(keys, error = null, newKey = null, pendingQueueCount = 0
         const msgNav = document.getElementById('messages-nav');
         if (msgNav) {
           msgNav.style.display = data.messagingEnabled ? '' : 'none';
+        }
+      });
+
+      // Localize UTC dates to browser timezone
+      document.querySelectorAll('.utc-date').forEach(function(el) {
+        const utc = el.dataset.utc;
+        if (utc) {
+          el.textContent = new Date(utc).toLocaleString();
         }
       });
     });


### PR DESCRIPTION
## Summary

Dates now display in the browser's local timezone instead of UTC.

## Changes

- Added `localDate()` helper that outputs `<span class="utc-date" data-utc="...">`
- Added client-side JS to localize dates on DOMContentLoaded
- Updated all 4 pages: dashboard, queue, messages, keys

## How It Works

1. Server outputs dates with data-utc attribute containing ISO string
2. Client-side JS converts to local timezone using `toLocaleString()`

Assigned by Pippin 🧙‍♂️