### PR TITLE
fix: Move script tag outside style tag in messages page

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -1619,8 +1619,8 @@ function renderMessagesPage(messages, filter, counts, mode, pendingQueueCount = 
   <title>agentgate - Agent Messages</title>
   <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">
   <link rel="stylesheet" href="/public/style.css">
-  <style>
   <script src="/socket.io/socket.io.js"></script>
+  <style>
     .filter-bar { display: flex; gap: 10px; margin-bottom: 24px; flex-wrap: wrap; align-items: center; }
     .filter-link {
       padding: 10px 20px;


### PR DESCRIPTION
The socket.io script tag was incorrectly placed inside the style tag, causing CSS to not be parsed correctly. Swapped the order so script comes before style, matching the queue page structure.