### PR TITLE
fix: LinkedIn OAuth scope - add w_member_social (Issue #54)

### DIFF
--- a/src/routes/ui/linkedin.js
+++ b/src/routes/ui/linkedin.js
@@ -9,7 +9,7 @@ export function registerRoutes(router, baseUrl) {
     setAccountCredentials('linkedin', accountName, { clientId, clientSecret });
 
     const redirectUri = `${baseUrl}/ui/linkedin/callback`;
-    const scope = 'openid profile email r_liteprofile';
+    const scope = 'openid profile email r_liteprofile w_member_social';
     const state = `agentgate_linkedin_${accountName}`;
 
     const authUrl = 'https://www.linkedin.com/oauth/v2/authorization?' +


### PR DESCRIPTION
Closes #54

Adds w_member_social scope to LinkedIn OAuth request. Required for posting.

Existing tokens will need to be re-authorized to get the new scope.

🧙‍♂️