### PR TITLE
fix: remove unauthorized openid scope from LinkedIn OAuth

### DIFF
--- a/src/routes/ui/linkedin.js
+++ b/src/routes/ui/linkedin.js
@@ -9,7 +9,7 @@ export function registerRoutes(router, baseUrl) {
     setAccountCredentials('linkedin', accountName, { clientId, clientSecret });
 
     const redirectUri = `${baseUrl}/ui/linkedin/callback`;
-    const scope = 'openid profile email r_liteprofile w_member_social';
+    const scope = 'profile email w_member_social';
     const state = `agentgate_linkedin_${accountName}`;
 
     const authUrl = 'https://www.linkedin.com/oauth/v2/authorization?' +


### PR DESCRIPTION
Fixes unauthorized_scope_error for openid.

Changed scope from:
`openid profile email r_liteprofile w_member_social`

To:
`profile email w_member_social`

openid requires special app configuration. r_liteprofile is deprecated.

🧙‍♂️