### PR TITLE
fix: add withdrawn to filters in ui.js (fixes withdraw visibility)

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -1119,7 +1119,7 @@ function renderQueuePage(entries, filter, counts = 0, pendingQueueCount = 0, pen
     `;
   };
 
-  const filters = ['all', 'pending', 'completed', 'failed', 'rejected'];
+  const filters = ['all', 'pending', 'completed', 'failed', 'rejected', 'withdrawn'];
   const filterLinks = filters.map(f =>
     `<a href="/ui/queue?filter=${f}" class="filter-link ${filter === f ? 'active' : ''}">${f}${counts[f] > 0 ? ` (${counts[f]})` : ''}</a>`
   ).join('');
@@ -1345,6 +1345,7 @@ function renderQueuePage(entries, filter, counts = 0, pendingQueueCount = 0, pen
       ${filter === 'completed' && counts.completed > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'completed\')">Clear Completed</button>' : ''}
       ${filter === 'failed' && counts.failed > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'failed\')">Clear Failed</button>' : ''}
       ${filter === 'rejected' && counts.rejected > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'rejected\')">Clear Rejected</button>' : ''}
+      ${filter === 'withdrawn' && counts.withdrawn > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'withdrawn\')">Clear Withdrawn</button>' : ''}
       ${filter === 'all' && (counts.completed > 0 || counts.failed > 0 || counts.rejected > 0) ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'all\')">Clear All Non-Pending</button>' : ''}
     </div>
     <div class="export-section">
@@ -1373,7 +1374,7 @@ function renderQueuePage(entries, filter, counts = 0, pendingQueueCount = 0, pen
     };
 
     function updateCounts(counts) {
-      const filters = ['all', 'pending', 'completed', 'failed', 'rejected'];
+      const filters = ['all', 'pending', 'completed', 'failed', 'rejected', 'withdrawn'];
       const filterBar = document.getElementById('filter-bar');
       const links = filterBar.querySelectorAll('.filter-link');
       links.forEach((link, i) => {
@@ -1952,6 +1953,7 @@ function renderMessagesPage(messages, filter, counts, mode, pendingQueueCount = 
     <div class="clear-section">
       ${filter === 'delivered' && counts.delivered > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'delivered\')">Clear Delivered</button>' : ''}
       ${filter === 'rejected' && counts.rejected > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'rejected\')">Clear Rejected</button>' : ''}
+      ${filter === 'withdrawn' && counts.withdrawn > 0 ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'withdrawn\')">Clear Withdrawn</button>' : ''}
       ${filter === 'all' && (counts.delivered > 0 || counts.rejected > 0) ? '<button type="button" class="btn-sm btn-danger" onclick="clearByStatus(\'all\')">Clear All Non-Pending</button>' : ''}
     </div>
     <div class="export-section">


### PR DESCRIPTION
## Problem

PR #61 was merged but withdraw filter is still missing. Root cause: PR #61 modified `src/routes/ui/queue.js` but the app imports from `src/routes/ui.js` (the monolithic 92KB file).

## Fix

Adds 'withdrawn' to the correct file:

1. **Line 1122** - Server-side filters array
2. **Line 1376** - Client-side filters array
3. **Line 1348** - Clear Withdrawn button

## Testing

1. Go to queue page
2. Verify 'withdrawn' filter tab appears
3. Verify withdrawn items are visible
4. Verify Clear Withdrawn button works

Closes the withdraw visibility bug Luis reported.