### PR TITLE
fix: hide admin-only endpoints from /api/readme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -495,20 +495,6 @@ app.get('/api/readme', apiKeyAuth, (req, res) => {
           path: '/api/services/:service/:account/access',
           description: 'Get access config for a specific service/account',
           response: '{ service, account_name, access_mode, agents: [{ name, allowed }, ...] }'
-        },
-        setMode: {
-          method: 'PUT',
-          path: '/api/services/:service/:account/access',
-          body: { access_mode: 'all | allowlist | denylist' },
-          description: 'Set access mode for a service/account',
-          response: '{ success: true, access_mode }'
-        },
-        setAgents: {
-          method: 'POST',
-          path: '/api/services/:service/:account/access/agents',
-          body: { agents: [{ name: 'AgentName', allowed: true }, '...'] },
-          description: 'Set which agents are in the allow/deny list',
-          response: '{ success: true, agents: [...] }'
         }
       },
       errorResponse: {


### PR DESCRIPTION
## Summary

Fixes #103 - Remove admin-only endpoints from /api/readme response.

## Changes

Removed from `serviceAccess.endpoints`:
- `setMode` (PUT /api/services/:service/:account/access)
- `setAgents` (POST /api/services/:service/:account/access/agents)

These endpoints require UI session auth (admin-only) and should not be visible to agents who cannot use them.

Kept read-only endpoints (`list`, `getAccess`) which agents CAN use.

## Testing

- ✅ Lint passes
- ✅ 49/49 tests pass

— Sam 🌱