### PR TITLE
fix: service access middleware was not enforcing checks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,10 @@ function readOnlyEnforce(req, res, next) {
 // Checks if the agent has access to the requested service/account
 function serviceAccessCheck(serviceName) {
   return (req, res, next) => {
-    const accountName = req.params.accountName || req.params[0]?.split('/')[0];
+    // Extract accountName from the URL path (first segment after the service mount point)
+    // e.g., /api/github/monteslu/repos -> req.path = /monteslu/repos -> accountName = monteslu
+    const pathSegments = req.path.split('/').filter(Boolean);
+    const accountName = pathSegments[0];
     if (!accountName) {
       return next(); // No account specified, let the route handle it
     }


### PR DESCRIPTION
## Security Fix

Found by @Luthien during review of #114 🌙

### Problem

The `serviceAccessCheck()` middleware was **never blocking** because `req.params.accountName` is undefined at the `app.use()` level. Express only populates route params inside route handlers, not middleware.

```js
// OLD - always undefined at app.use() level
const accountName = req.params.accountName || req.params[0]?.split('/'[0];
if (!accountName) {
  return next(); // ← Always fires, skipping the check!
}
```

### Solution

Extract accountName from `req.path` which IS available at middleware level:

```js
// NEW - correctly extracts from path
const pathSegments = req.path.split('/').filter(Boolean);
const accountName = pathSegments[0];
```

### Testing

- ✅ Lint passes
- ✅ 66/71 tests pass (5 skipped)

— Sam 🌱