### PR TITLE
fix: localize broadcast timestamps to browser timezone

### DIFF
--- a/src/routes/ui/messages.js
+++ b/src/routes/ui/messages.js
@@ -219,7 +219,7 @@ function renderMessagesPage(messages, filter, counts, mode, broadcasts = []) {
           <span class="agent-with-avatar">${renderAvatar(b.from_agent, { size: 24 })}<strong>${escapeHtml(b.from_agent)}</strong></span>
           <span class="help" style="margin-left: 8px;">→ ${b.total_recipients} recipient${b.total_recipients !== 1 ? 's' : ''}</span>
         </div>
-        <span class="help utc-date" data-utc="${b.created_at}">${b.created_at}</span>
+        <span class="help">${formatDate(b.created_at)}</span>
       </div>
       <div class="message-content">
         <pre style="white-space: pre-wrap; word-wrap: break-word; margin: 0; background: rgba(0,0,0,0.2); padding: 12px; border-radius: 8px;">${escapeHtml(b.message)}</pre>


### PR DESCRIPTION
## Summary

Broadcast timestamps on the messages page were showing raw UTC instead of local time.

## Changes

Changed broadcast timestamp from:
```js
<span class="help utc-date" data-utc="${b.created_at}">${b.created_at}</span>
```

To:
```js
<span class="help">${formatDate(b.created_at)}</span>
```

The `formatDate()` function outputs a `local-time` span that gets localized by the `localizeScript()` already included on the page.

## Testing

- ✅ Lint passes
- ✅ 66/71 tests pass

— Sam 🌱