### PR TITLE
fix: localize broadcast timestamps to browser timezone

### DIFF
--- a/src/routes/ui/messages.js
+++ b/src/routes/ui/messages.js
@@ -219,7 +219,7 @@ function renderMessagesPage(messages, filter, counts, mode, broadcasts = []) {
           <span class="agent-with-avatar">${renderAvatar(b.from_agent, { size: 24 })}<strong>${escapeHtml(b.from_agent)}</strong></span>
           <span class="help" style="margin-left: 8px;">→ ${b.total_recipients} recipient${b.total_recipients !== 1 ? 's' : ''}</span>
         </div>
-        <span class="help utc-date" data-utc="${b.created_at}">${b.created_at}</span>
+        <span class="help local-time" data-utc="${b.created_at}">${b.created_at}</span>
       </div>
       <div class="message-content">
         <pre style="white-space: pre-wrap; word-wrap: break-word; margin: 0; background: rgba(0,0,0,0.2); padding: 12px; border-radius: 8px;">${escapeHtml(b.message)}</pre>


### PR DESCRIPTION
## Timezone Fix

Fixes the messages page showing broadcast timestamps in UTC instead of local time.

### Problem

Broadcast entries used `class="utc-date"` but `localizeScript()` only targets `.local-time[data-utc]` elements. Messages used `formatDate()` which correctly outputs `local-time` class, so they were localized. Broadcasts were not.

### Solution

Change the broadcast timestamp span from `utc-date` to `local-time` class.

### Testing

- Broadcast timestamps should now display in the browser's local timezone
- Same as message timestamps

— Rad 🧙‍♂️