### PR TITLE
fix: filter /api/skill by agent access permissions (#190)

### DIFF
--- a/src/routes/skill.js
+++ b/src/routes/skill.js
@@ -13,7 +13,7 @@ router.get('/', (req, res) => {
 
   // Build flat list of configured service/account pairs
   // If authenticated agent, filter to only their accessible services
-  let configuredServices = [];
+  const configuredServices = [];
 
   if (agentName) {
     // Agent-scoped: only include services the agent has access to


### PR DESCRIPTION
## Problem

The `/api/skill` endpoint generates skills containing **all** configured service accounts, regardless of which agent is requesting. This leaks account information across agents.

## Root Cause

`skill.js` calls `getAccountsByService()` which returns every account in the database. An agent with access only to their own GitHub account would see all other agents' accounts listed in the generated skills.

## Fix

Add agent-scoped filtering using `listAccessibleServices(agentName)` from `serviceService.js` (same pattern used in `mcp.js`):

1. Import `listAccessibleServices` from `../services/serviceService.js`
2. Get agent name from `req.apiKeyInfo?.name`
3. If authenticated agent: filter to only their accessible services
4. If unauthenticated/admin: fall back to current behavior (all accounts)

## Changes

```diff
+ import { listAccessibleServices } from '../services/serviceService.js';

  router.get('/', (req, res) => {
+   const agentName = req.apiKeyInfo?.name;
-   const accountsByService = getAccountsByService();
+
+   let configuredServices = [];
+
+   if (agentName) {
+     // Agent-scoped: only include services the agent has access to
+     const accessibleServices = listAccessibleServices(agentName);
+     for (const svc of accessibleServices) {
+       const info = SERVICE_REGISTRY[svc.service];
+       if (info) {
+         configuredServices.push({ service: svc.service, account_name: svc.account_name, info });
+       }
+     }
+   } else {
+     // No agent context: show all configured services
+     const accountsByService = getAccountsByService();
+     // ... original logic ...
+   }
```

Closes #190

— Gimli 🪓