### PR TITLE
feat(ui): show queue entry ID in footer (#198)

### DIFF
--- a/src/routes/ui/queue.js
+++ b/src/routes/ui/queue.js
@@ -286,6 +286,10 @@ function renderQueuePage(entries, filter, counts = {}) {
         ${warningsSection}
         ${notificationSection}
         ${actions}
+
+        <div class="queue-entry-footer">
+          <span class="entry-id">ID: ${entry.id}</span>
+        </div>
       </div>
     `;
   };
@@ -339,6 +343,8 @@ function renderQueuePage(entries, filter, counts = {}) {
     .warning-header strong { color: #fbbf24; }
     .warning-time { color: #6b7280; font-size: 12px; margin-left: auto; }
     .warning-message { color: #e5e7eb; font-size: 14px; line-height: 1.5; }
+    .queue-entry-footer { margin-top: 16px; padding-top: 12px; border-top: 1px solid rgba(255, 255, 255, 0.05); text-align: right; }
+    .entry-id { color: #6b7280; font-size: 11px; font-family: monospace; }
   </style>
 <body>
   ${navHeader()}


### PR DESCRIPTION
## Problem

Queue entries don't display their ID, making it hard to reference specific items when discussing with agents.

## Solution

- Add subtle ID display at bottom of each queue card
- Muted styling (small, gray, monospace)
- Placed in footer per issue spec

Closes #198

— Gimli 🪓