### PR TITLE
fix: use window.location.origin for webhook URL (#208)

### DIFF
--- a/src/routes/ui/webhooks.js
+++ b/src/routes/ui/webhooks.js
@@ -479,7 +479,7 @@ ${renderStyles()}
 function renderWebhookDetailPage(config, deliveries, alerts = {}) {
   const source = WEBHOOK_SOURCES[config.source] || { name: config.source, icon: '/public/favicon.svg', events: [] };
   const secret = getWebhookSecret(config.source) || config.secret || 'Not configured';
-  const webhookUrl = `${process.env.BASE_URL || 'http://localhost:3000'}/webhooks/${config.source}`;
+  const webhookPath = `/webhooks/${config.source}`;
   
   const eventCheckboxes = source.events.map(e => {
     const checked = (config.events || []).includes(e.id) ? 'checked' : '';
@@ -523,8 +523,12 @@ ${renderStyles()}
   <div class="card">
     <h3>Webhook Endpoint</h3>
     <p class="help">Configure your ${source.name} repository to send webhooks to this URL:</p>
-    <div class="endpoint-url">${escapeHtml(webhookUrl)}</div>
+    <div class="endpoint-url" id="webhook-url" data-path="${escapeHtml(webhookPath)}"></div>
   </div>
+  <script>
+    // Set webhook URL using client-side origin (handles reverse proxies correctly)
+    document.getElementById('webhook-url').textContent = window.location.origin + document.getElementById('webhook-url').dataset.path;
+  </script>
   
   <div class="card">
     <h3>Webhook Secret</h3>


### PR DESCRIPTION
## Summary

Fixes the webhook endpoint URL display to use `window.location.origin` instead of a hardcoded `localhost:3000`.

## Problem

The webhook management UI showed `http://localhost:3000/webhooks/github` regardless of how agentgate was actually being accessed. This breaks when using reverse proxies or external URLs.

## Solution

- Changed from server-side rendered URL to client-side computed URL
- Uses `window.location.origin + path` so it always matches the actual access URL
- Added data attribute for the path, JavaScript computes full URL on page load

## Testing

- [x] Lint passes
- [x] Tests pass (70 passed, 5 skipped)

Closes #208