### PR TITLE
fix(security): validate reaction emoji server-side

### DIFF
--- a/src/routes/ui/queue.js
+++ b/src/routes/ui/queue.js
@@ -12,6 +12,15 @@ import { escapeHtml, renderMarkdownLinks, statusBadge, autoApprovedBadge, format
 
 const router = Router();
 
+// Allowed reaction emojis (must match UI picker)
+const ALLOWED_REACTION_EMOJIS = new Set(['❤️', '🔥', '👏', '⭐', '👎', '😠', '💀']);
+
+// Validate and sanitize reaction emoji
+function validateReactionEmoji(emoji) {
+  if (!emoji) return null;
+  return ALLOWED_REACTION_EMOJIS.has(emoji) ? emoji : null;
+}
+
 // Write Queue Management
 router.get('/', (req, res) => {
   const filter = req.query.filter || 'pending';
@@ -46,7 +55,7 @@ router.post('/:id/approve', async (req, res) => {
       : res.status(400).send('Can only approve pending requests');
   }
 
-  updateQueueStatus(id, 'approved', { reaction_emoji: emoji || null });
+  updateQueueStatus(id, 'approved', { reaction_emoji: validateReactionEmoji(emoji) });
 
   try {
     await executeQueueEntry(entry);
@@ -89,7 +98,7 @@ router.post('/:id/reject', async (req, res) => {
       : res.status(400).send('Can only reject pending requests');
   }
 
-  updateQueueStatus(id, 'rejected', { rejection_reason: reason || 'No reason provided', reaction_emoji: emoji || null });
+  updateQueueStatus(id, 'rejected', { rejection_reason: reason || 'No reason provided', reaction_emoji: validateReactionEmoji(emoji) });
 
   const updated = getQueueEntry(id);
   notifyAgentQueueStatus(updated).catch(err => {


### PR DESCRIPTION
## Summary

Adds server-side validation for reaction emoji per Luthien's review.

## Changes

- Added `ALLOWED_REACTION_EMOJIS` set (❤️🔥👏⭐👎😠💀)
- Added `validateReactionEmoji()` helper
- Approve/reject handlers now validate emoji before storing
- Invalid/unknown emojis are silently ignored (stored as null)

## Why

Prevents arbitrary text from being stored in `reaction_emoji` field if someone calls the API directly.

## Testing

- [x] Lint passes
- [x] All tests pass

Per Luthien's review on #214.