### PR TITLE
fix: MCP sessions not persisting on restart

### DIFF
--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -178,7 +178,8 @@ export function createMCPPostHandler() {
 
                 transport.onclose = () => {
                   activeSessions.delete(sessionId);
-                  deleteMcpSession(sessionId);
+                  // Don't delete from DB - session can be recreated after restart
+                  // DB cleanup via TTL expiry or admin kill
                 };
 
                 const now = Date.now();
@@ -240,7 +241,7 @@ export function createMCPPostHandler() {
           const sid = transport.sessionId;
           if (sid) {
             activeSessions.delete(sid);
-            deleteMcpSession(sid);
+            // Don't delete from DB - allows recreation after server restart
           }
         };
 


### PR DESCRIPTION
## Problem\n\nMCP sessions are not persisting across server restarts despite PR #223 adding SQLite persistence.\n\n## Root Cause\n\n`transport.onclose` handlers delete sessions from BOTH memory AND database:\n\n```javascript\ntransport.onclose = () => {\n  activeSessions.delete(sessionId);\n  deleteMcpSession(sessionId);  // ← BUG\n};\n```\n\nWhen server shuts down → all transports close → onclose fires → DB wiped.\n\n## Fix\n\nRemove `deleteMcpSession()` from onclose handlers. Sessions should only be deleted from DB when:\n1. Admin explicitly kills the session\n2. TTL cleanup runs (stale sessions)\n\n## Testing\n\n- Lint: clean\n- Tests: 70 passed, 5 skipped\n\n/cc @luthien-m for security review