### PR TITLE
fix: MCP session list UI formatting (#230)

### DIFF
--- a/src/routes/ui/keys.js
+++ b/src/routes/ui/keys.js
@@ -544,6 +544,13 @@ function renderKeysPage(keys, error = null, newKey = null) {
     .toast.show { opacity: 1; transform: translateY(0); }
     .toast.error { background: #dc2626; }
     .toast.success { background: #059669; }
+
+    /* Session table styling */
+    .sessions-table .session-id { font-family: monospace; font-size: 12px; background: rgba(99,102,241,0.15); padding: 2px 6px; border-radius: 3px; }
+    .sessions-table .timestamp { font-size: 13px; color: #9ca3af; white-space: nowrap; }
+    .status-badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 12px; font-weight: 500; }
+    .status-active { background: rgba(16,185,129,0.15); color: #10b981; }
+    .status-db { background: rgba(107,114,128,0.15); color: #9ca3af; }
   </style>
 </head>
 <body>
@@ -1251,11 +1258,44 @@ function renderAgentDetailPage(agent, counts, serviceAccess = []) {
         }
 
         killAllBtn.style.display = '';
-        let html = '<table class="agents-table"><thead><tr><th>Session ID</th><th>Created</th><th>Last Seen</th><th>Status</th><th></th></tr></thead><tbody>';
+        
+        // Format timestamp to human-readable local time
+        function formatTime(dateStr) {
+          if (!dateStr) return '-';
+          try {
+            const d = new Date(dateStr);
+            const now = new Date();
+            const diffMs = now - d;
+            const diffMins = Math.floor(diffMs / 60000);
+            const diffHours = Math.floor(diffMs / 3600000);
+            const diffDays = Math.floor(diffMs / 86400000);
+            
+            // Relative time for recent timestamps
+            if (diffMins < 1) return 'just now';
+            if (diffMins < 60) return diffMins + 'm ago';
+            if (diffHours < 24) return diffHours + 'h ago';
+            if (diffDays < 7) return diffDays + 'd ago';
+            
+            // Full date for older timestamps
+            return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+          } catch { return dateStr; }
+        }
+        
+        let html = '<table class="agents-table sessions-table"><thead><tr><th>Session ID</th><th>Created</th><th>Last Seen</th><th>Status</th><th></th></tr></thead><tbody>';
         for (const s of data.sessions) {
           const shortId = s.sessionId.substring(0, 8) + '...';
-          const status = s.active ? '<span style="color: #10b981;">● Active</span>' : '<span style="color: #6b7280;">○ DB Only</span>';
-          html += '<tr><td title="' + s.sessionId + '"><code>' + shortId + '</code></td><td>' + (s.createdAt || '-') + '</td><td>' + (s.lastSeen || '-') + '</td><td>' + status + '</td><td><button class="btn-sm btn-danger kill-session-btn" data-session-id="' + s.sessionId + '">Kill</button></td></tr>';
+          const status = s.active 
+            ? '<span class="status-badge status-active">● Active</span>' 
+            : '<span class="status-badge status-db">○ DB Only</span>';
+          const created = formatTime(s.createdAt);
+          const lastSeen = formatTime(s.lastSeen);
+          html += '<tr>' +
+            '<td title="' + s.sessionId + '"><code class="session-id">' + shortId + '</code></td>' +
+            '<td class="timestamp" title="' + (s.createdAt || '') + '">' + created + '</td>' +
+            '<td class="timestamp" title="' + (s.lastSeen || '') + '">' + lastSeen + '</td>' +
+            '<td>' + status + '</td>' +
+            '<td><button class="btn-sm btn-danger kill-session-btn" data-session-id="' + s.sessionId + '">Kill</button></td>' +
+            '</tr>';
         }
         html += '</tbody></table>';
         container.innerHTML = html;


### PR DESCRIPTION
## Problem\n\nMCP session list in admin UI has poor formatting - raw ISO timestamps, no visual hierarchy.\n\n## Changes\n\n- **Human-readable timestamps**: Shows relative time (\"5m ago\", \"2h ago\", \"3d ago\") for recent activity, full date for older\n- **Tooltip on hover**: Raw ISO timestamp available on hover for precision\n- **Better styling**: Status badges with proper colors, monospace session IDs, cleaner table layout\n\n## Before\n```\nSession ID Created Last Seen Status\n8da92d88... 2026-02-12T15:40:12.385Z 2026-02-12T15:41:11.185Z ● Active Kill\n```\n\n## After\n```\nSession ID    Created    Last Seen    Status\n8da92d88...   25m ago    2m ago       ● Active    [Kill]\n```\n\n## Testing\n\n- Lint: clean\n- Tests: 70 passed\n\nFixes #230\n\n/cc @luthien-m