### PR TITLE
fix: compute gateway proxy URLs from window.location (#244)

### DIFF
--- a/src/routes/ui/keys.js
+++ b/src/routes/ui/keys.js
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { writeFileSync } from 'fs';
 import crypto from 'crypto';
 import { listApiKeys, createApiKey, deleteApiKey, regenerateApiKey, updateAgentWebhook, updateAgentBio, getApiKeyById, getAvatarsDir, getAvatarFilename, deleteAgentAvatar, setAgentEnabled, setAgentRawResults, updateGatewayProxy, regenerateProxyId, getAgentDataCounts, getAgentServiceAccess, listMcpSessions, updateChannel, disableChannel } from '../../lib/db.js';
-import { escapeHtml, formatDate, htmlHead, navHeader, socketScript, localizeScript, menuScript, renderAvatar, BASE_URL } from './shared.js';
+import { escapeHtml, formatDate, htmlHead, navHeader, socketScript, localizeScript, menuScript, renderAvatar } from './shared.js';
 
 const router = Router();
 
@@ -2022,11 +2022,6 @@ function renderAgentDetailPage(agent, counts, serviceAccess = [], adminChatToken
   ${localizeScript()}
 </body>
 </html>`;
-}
-
-function getProxyUrl(proxyId) {
-  if (!proxyId) return '';
-  return BASE_URL + '/px/' + proxyId + '/';
 }
 
 function getServiceIcon(service) {


### PR DESCRIPTION
## Summary

Fixes #244 — improves gateway proxy URL display in admin UI.

## Problem

The proxy URL used server-side BASE_URL which may not match client's view.

## Solution

Same pattern as PR #243:
- Show HTTP and WebSocket proxy URLs with clear labels
- Compute from window.location at runtime
- Copy button copies WebSocket URL