### PR TITLE
Fix: bypass_auth crash — createQueueEntry returns incomplete object

### DIFF
--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -95,7 +95,9 @@ export async function submitWriteRequest(
     try {
       markAutoApproved(entry.id);
       updateQueueStatus(entry.id, 'approved');
-      await executeQueueEntry({ ...entry, status: 'approved' });
+      // Fetch the full entry from DB (createQueueEntry only returns {id, status})
+      const fullEntry = getQueueEntry(entry.id);
+      await executeQueueEntry(fullEntry);
       const updatedEntry = getQueueEntry(entry.id);
 
       if (emitEvents) {


### PR DESCRIPTION
Fixes #240

`createQueueEntry()` returns `{ id, status }` but `executeQueueEntry()` needs the full row with `requests`, `service`, `account_name` etc.

The fix: call `getQueueEntry(entry.id)` to get the full parsed row before passing to `executeQueueEntry()`.

One-line change in the bypass_auth code path.