### PR TITLE
fix: YouTube UI form should use OAuth fields, not API key

### DIFF
--- a/src/routes/ui/service-detail.js
+++ b/src/routes/ui/service-detail.js
@@ -608,9 +608,13 @@ function getServiceFormFields(serviceName) {
 
     youtube: `
       <div class="form-group">
-        <label>API Key</label>
-        <input type="password" name="apiKey" placeholder="Your YouTube API key" required autocomplete="off">
-        <p class="help">Get an API key from <a href="https://console.cloud.google.com/apis/credentials" target="_blank">Google Cloud Console</a></p>
+        <label>Client ID</label>
+        <input type="text" name="clientId" placeholder="xxxxx.apps.googleusercontent.com" required autocomplete="off">
+      </div>
+      <div class="form-group">
+        <label>Client Secret</label>
+        <input type="password" name="clientSecret" placeholder="Your client secret" required autocomplete="off">
+        <p class="help">Enable YouTube Data API v3 at <a href="https://console.cloud.google.com/apis/credentials" target="_blank">Google Cloud Console</a></p>
       </div>`,
 
     linkedin: `


### PR DESCRIPTION
## Problem

The "Add YouTube Account" form in `service-detail.js` shows an **API Key** field, but the YouTube service is OAuth-only. The setup handler at `/ui/youtube/setup` expects `clientId` and `clientSecret` — so submitting an API key does nothing useful.

## Fix

Replaced the single API Key field with **Client ID** and **Client Secret** fields, matching:
- The YouTube setup handler in `youtube.js` (expects `clientId` + `clientSecret`)
- The OAuth2 authorization code flow the service actually uses
- The pattern used by other Google OAuth services (Calendar, Fitbit)

## Testing

- Navigate to Add YouTube Account in the admin UI
- Verify form shows Client ID + Client Secret fields
- Submit triggers OAuth consent flow correctly