### PR TITLE
fix: Cannot POST /ui/google_calendar/setup

### DIFF
--- a/src/routes/ui/service-detail.js
+++ b/src/routes/ui/service-detail.js
@@ -522,7 +522,7 @@ function renderAddService(serviceModule) {
   </div>
 
   <div class="card">
-    <form method="POST" action="/ui/${serviceName}/setup">
+    <form method="POST" action="/ui/${serviceRoutePrefix(serviceName)}/setup">
       <div class="form-group">
         <label>Account Name</label>
         <input type="text" name="accountName" placeholder="personal, work, etc." required autocomplete="off">
@@ -543,6 +543,11 @@ function renderAddService(serviceModule) {
   ${localizeScript()}
 </body>
 </html>`;
+}
+
+function serviceRoutePrefix(serviceName) {
+  const prefixes = { google_calendar: 'google' };
+  return prefixes[serviceName] || serviceName;
 }
 
 function getServiceFormFields(serviceName) {


### PR DESCRIPTION
## Problem

The generic setup form in `service-detail.js` builds the action URL as `/ui/${serviceName}/setup`. For Google Calendar, this produces `/ui/google_calendar/setup`, but the actual route in `calendar.js` is `/ui/google/setup`.

## Fix

Added `serviceRoutePrefix()` helper that maps service names to their route prefixes:
- `google_calendar` → `google`
- Everything else passes through unchanged

Form action now uses `/ui/${serviceRoutePrefix(serviceName)}/setup`.