### PR TITLE
fix: mastodon service-detail form uses wrong endpoint and field names

### DIFF
--- a/src/routes/ui/service-detail.js
+++ b/src/routes/ui/service-detail.js
@@ -522,7 +522,7 @@ function renderAddService(serviceModule) {
   </div>
 
   <div class="card">
-    <form method="POST" action="/ui/${serviceRoutePrefix(serviceName)}/setup">
+    <form method="POST" action="/ui/${serviceRoutePrefix(serviceName)}/${getServiceSetupAction(serviceName)}">
       <div class="form-group">
         <label>Account Name</label>
         <input type="text" name="accountName" placeholder="personal, work, etc." required autocomplete="off">
@@ -550,6 +550,11 @@ function serviceRoutePrefix(serviceName) {
   return prefixes[serviceName] || serviceName;
 }
 
+function getServiceSetupAction(serviceName) {
+  const actions = { mastodon: 'token-setup' };
+  return actions[serviceName] || 'setup';
+}
+
 function getServiceFormFields(serviceName) {
   const fields = {
     github: `
@@ -572,13 +577,14 @@ function getServiceFormFields(serviceName) {
 
     mastodon: `
       <div class="form-group">
-        <label>Instance URL</label>
-        <input type="text" name="instanceUrl" placeholder="https://mastodon.social" required autocomplete="off">
+        <label>Instance</label>
+        <input type="text" name="instance" placeholder="mastodon.social" required autocomplete="off">
+        <p class="help">Just the domain, no https://</p>
       </div>
       <div class="form-group">
         <label>Access Token</label>
         <input type="password" name="accessToken" placeholder="Your access token" required autocomplete="off">
-        <p class="help">Get a token from your instance's Development settings</p>
+        <p class="help">Go to your instance → Preferences → Development → New Application, create an app with <code>read</code> + <code>write:statuses</code> scopes, then copy the access token</p>
       </div>`,
 
     reddit: `


### PR DESCRIPTION
## Problem

The Mastodon "Add Account" form on the service-detail page (`/ui/services/:id`) was broken:

1. **Wrong endpoint** — form posted to `/ui/mastodon/setup` (OAuth dynamic registration flow) but the fields were for the token-paste flow
2. **Field name mismatch** — form sent `instanceUrl` but the handler expects `instance`

This caused "Account name and instance required" errors on submit.

## Fix

- Change form action to `/ui/mastodon/token-setup` (the token paste endpoint that matches the form fields)
- Rename `instanceUrl` → `instance` to match the handler
- Update placeholder to domain-only format (no `https://`)
- Add clearer help text for getting an access token
- Add `getServiceSetupAction()` helper for per-service form action overrides