### PR TITLE
fix: replace channel setup auto-redirect with Continue button (#274)

### DIFF
--- a/views/pages/key-detail.ejs
+++ b/views/pages/key-detail.ejs
@@ -546,9 +546,8 @@
       document.getElementById('channel-enable-btn').style.display = 'none';
       const card = document.getElementById('channel-enable-btn').closest('.config-card');
       const keyDiv = document.createElement('div');
-      keyDiv.innerHTML = '<div class="proxy-url-box"><code>' + data.channel_key + '</code><button type="button" class="btn-copy-sm" onclick="navigator.clipboard.writeText(\'' + data.channel_key + '\');showToast(\'Copied!\',\'success\')">Copy</button></div><p class="help-text text-warning">⚠️ Save this key — it won\'t be shown again. Page will reload in 5s.</p>';
+      keyDiv.innerHTML = '<div class="proxy-url-box"><code>' + data.channel_key + '</code><button type="button" class="btn-copy-sm" onclick="navigator.clipboard.writeText(\'' + data.channel_key + '\');showToast(\'Copied!\',\'success\')">Copy</button></div><p class="help-text text-warning">⚠️ Save this key — it won\'t be shown again.</p><button type="button" class="btn-primary" style="margin-top:12px" onclick="location.reload()">Continue</button>';
       card.appendChild(keyDiv);
-      setTimeout(() => location.reload(), 5000);
     } else {
       showToast(data.error || 'Failed', 'error');
       this.disabled = false;


### PR DESCRIPTION
Fixes #274

## Problem

After enabling a channel on the agent detail page, the page shows the channel key with a warning to save it, then auto-reloads after 5 seconds. Too fast for users to read and copy the key.

## Fix

Replaced `setTimeout(() => location.reload(), 5000)` with a manual **"Continue"** button. Users click it when they're done copying the key.

- Removed: `Page will reload in 5s` warning text
- Removed: `setTimeout` auto-reload
- Added: `Continue` button that triggers `location.reload()`

The regenerate key flow already works correctly (no auto-redirect), so no changes needed there.