### PR TITLE
Fix #276: Invalid regex error from ALLOWED_URI_REGEXP in chat sanitizer

### DIFF
--- a/src/routes/ui/keys.js
+++ b/src/routes/ui/keys.js
@@ -626,7 +626,7 @@ function getChatScript() {
           ALLOW_DATA_ATTR: false,
           ADD_ATTR: ['target'],
           FORCE_BODY: true,
-          ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|[^a-z]|[a-z+.\\\\-]+(?:[^a-z+.\\\\-:]|$))/i
+          ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
         });
       }
 


### PR DESCRIPTION
The ALLOWED_URI_REGEXP in DOMPurify config had quadruple backslashes in source. After template literal processing, the browser received double backslashes creating an invalid character class range.

**Fix:** Place `-` at end of character class — unambiguous, no escaping needed.

Fixes #276