### PR TITLE
fix: MCP sessions error handling for stuck loading state

### DIFF
--- a/src/routes/ui/keys.js
+++ b/src/routes/ui/keys.js
@@ -495,35 +495,40 @@ router.get('/:id/sessions', async (req, res) => {
     return res.status(404).json({ error: 'Agent not found' });
   }
 
-  const { getActiveSessionsInfo } = await import('../mcp.js');
-  const activeSessionsList = getActiveSessionsInfo().filter(
-    s => s.agentName.toLowerCase() === agent.name.toLowerCase()
-  );
-  const dbSessions = listMcpSessions(agent.name);
+  try {
+    const { getActiveSessionsInfo } = await import('../mcp.js');
+    const activeSessionsList = getActiveSessionsInfo().filter(
+      s => s.agentName.toLowerCase() === agent.name.toLowerCase()
+    );
+    const dbSessions = listMcpSessions(agent.name);
 
-  // Merge: use active session info where available, fall back to DB
-  const sessionMap = new Map();
-  for (const dbS of dbSessions) {
-    sessionMap.set(dbS.session_id, {
-      sessionId: dbS.session_id,
-      agentName: dbS.agent_name,
-      createdAt: dbS.created_at,
-      lastSeen: dbS.last_seen_at,
-      active: false
-    });
-  }
-  for (const activeS of activeSessionsList) {
-    const existing = sessionMap.get(activeS.sessionId) || {};
-    sessionMap.set(activeS.sessionId, {
-      sessionId: activeS.sessionId,
-      agentName: activeS.agentName,
-      createdAt: activeS.createdAt || existing.createdAt || null,
-      lastSeen: activeS.lastSeen,
-      active: true
-    });
-  }
+    // Merge: use active session info where available, fall back to DB
+    const sessionMap = new Map();
+    for (const dbS of dbSessions) {
+      sessionMap.set(dbS.session_id, {
+        sessionId: dbS.session_id,
+        agentName: dbS.agent_name,
+        createdAt: dbS.created_at,
+        lastSeen: dbS.last_seen_at,
+        active: false
+      });
+    }
+    for (const activeS of activeSessionsList) {
+      const existing = sessionMap.get(activeS.sessionId) || {};
+      sessionMap.set(activeS.sessionId, {
+        sessionId: activeS.sessionId,
+        agentName: activeS.agentName,
+        createdAt: activeS.createdAt || existing.createdAt || null,
+        lastSeen: activeS.lastSeen,
+        active: true
+      });
+    }
 
-  res.json({ sessions: Array.from(sessionMap.values()) });
+    res.json({ sessions: Array.from(sessionMap.values()) });
+  } catch (err) {
+    console.error('Error loading sessions for agent', agent.name, err);
+    res.status(500).json({ error: 'Failed to load sessions', sessions: [] });
+  }
 });
 
 router.post('/:id/sessions/:sessionId/kill', async (req, res) => {

--- a/views/pages/key-detail.ejs
+++ b/views/pages/key-detail.ejs
@@ -660,7 +660,8 @@
   // Sessions
   async function loadSessions() {
     try {
-      const res = await fetch('/ui/keys/' + agentId + '/sessions');
+      const res = await fetch('/ui/keys/' + agentId + '/sessions', { headers: { 'Accept': 'application/json' } });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
       const data = await res.json();
       const container = document.getElementById('sessions-container');
       const killAllBtn = document.getElementById('kill-all-sessions-btn');


### PR DESCRIPTION
## Fix

Addresses the MCP sessions section being stuck on "Loading sessions..." indefinitely on the agent detail page.

### Changes

**`src/routes/ui/keys.js`**
- Wrapped the `GET /:id/sessions` route body in try/catch
- On error, returns `{ error: '...', sessions: [] }` with status 500 instead of an unhandled exception (which would return HTML)
- Logs the error server-side for debugging

**`views/pages/key-detail.ejs`**
- Added `Accept: application/json` header to the sessions fetch call
- Added `res.ok` check before parsing JSON — throws on non-2xx responses
- This ensures the catch block fires properly, showing "Failed to load sessions" instead of staying stuck on "Loading sessions..."

### Testing

- `npm test` — 70 passed, 5 skipped ✅
- `npm run lint` — clean ✅

Fixes #275