### PR TITLE
feat: forward agent headers to upstream services (#282)

### DIFF
--- a/src/lib/headerUtils.js
+++ b/src/lib/headerUtils.js
@@ -1,0 +1,80 @@
+/**
+ * Header forwarding utilities for service routes.
+ *
+ * Agents send requests to agentgate with their own Authorization header
+ * (the agentgate bearer token) plus any custom headers they want forwarded
+ * to upstream APIs (Accept, If-None-Match, X-GitHub-Api-Version, etc.).
+ *
+ * This module strips the agentgate auth and hop-by-hop headers, returning
+ * clean headers that can be merged with service-specific defaults.
+ */
+
+// Hop-by-hop headers per RFC 2616 Section 13.5.1
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade'
+]);
+
+// Headers that should never be forwarded to upstream services
+const STRIP_HEADERS = new Set([
+  'authorization',       // agentgate bearer token — replaced with service creds
+  'host',                // must reflect upstream target, not agentgate
+  'content-length',      // may differ after body transformation
+  'x-agentgate-raw'    // internal agentgate header
+]);
+
+/**
+ * Extract forwardable headers from an incoming request.
+ *
+ * @param {object} reqHeaders - The raw req.headers from Express
+ * @returns {object} Cleaned headers safe to forward upstream
+ */
+export function getForwardableHeaders(reqHeaders) {
+  if (!reqHeaders || typeof reqHeaders !== 'object') return {};
+
+  const forwarded = {};
+  for (const [key, value] of Object.entries(reqHeaders)) {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) continue;
+    if (STRIP_HEADERS.has(lower)) continue;
+    forwarded[key] = value;
+  }
+  return forwarded;
+}
+
+/**
+ * Merge service-specific default headers with agent-forwarded headers.
+ * Agent headers take precedence — defaults only apply if the agent
+ * didn't already set them.
+ *
+ * @param {object} defaults - Service-specific default headers
+ * @param {object} forwarded - Agent-forwarded headers (from getForwardableHeaders)
+ * @returns {object} Merged headers
+ */
+export function mergeHeaders(defaults, forwarded) {
+  // Start with defaults, then overlay agent headers
+  // We need case-insensitive comparison
+  const merged = { ...defaults };
+  const defaultKeysLower = new Map(
+    Object.keys(defaults).map(k => [k.toLowerCase(), k])
+  );
+
+  for (const [key, value] of Object.entries(forwarded)) {
+    const lower = key.toLowerCase();
+    // If the agent set a header that exists in defaults, remove the default key
+    // and use the agent's version
+    const existingKey = defaultKeysLower.get(lower);
+    if (existingKey && existingKey !== key) {
+      delete merged[existingKey];
+    }
+    merged[key] = value;
+  }
+
+  return merged;
+}

--- a/src/lib/queueExecutor.js
+++ b/src/lib/queueExecutor.js
@@ -1,5 +1,6 @@
 import { getAccountCredentials, setAccountCredentials, updateQueueStatus, getQueueEntry } from './db.js';
 import { notifyAgentQueueStatus } from './agentNotifier.js';
+import { getForwardableHeaders, mergeHeaders } from './headerUtils.js';
 
 // Service base URLs
 const SERVICE_URLS = {
@@ -245,28 +246,31 @@ function buildUrl(service, accountName, path) {
 
 // Build headers for a service request
 function buildHeaders(service, token, customHeaders = {}) {
-  const headers = {
+  // Start with service defaults
+  const defaults = {
     'Accept': 'application/json',
-    'Content-Type': 'application/json',
-    ...customHeaders
+    'Content-Type': 'application/json'
   };
 
   if (service === 'jira' && token?.email && token?.apiToken) {
-    // Jira uses basic auth
     const basicAuth = Buffer.from(`${token.email}:${token.apiToken}`).toString('base64');
-    headers['Authorization'] = `Basic ${basicAuth}`;
+    defaults['Authorization'] = `Basic ${basicAuth}`;
   } else if (token && typeof token === 'string') {
-    headers['Authorization'] = `Bearer ${token}`;
+    defaults['Authorization'] = `Bearer ${token}`;
   }
 
-  // Service-specific headers
+  // Service-specific defaults
   if (service === 'github') {
-    headers['Accept'] = 'application/vnd.github+json';
-    headers['User-Agent'] = 'agentgate-gateway';
+    defaults['Accept'] = 'application/vnd.github+json';
+    defaults['User-Agent'] = 'agentgate-gateway';
   }
   if (service === 'reddit') {
-    headers['User-Agent'] = 'agentgate-gateway/1.0';
+    defaults['User-Agent'] = 'agentgate-gateway/1.0';
   }
+
+  // Merge: agent-provided headers override defaults (except Authorization which is always from creds)
+  const forwarded = getForwardableHeaders(customHeaders);
+  const headers = mergeHeaders(defaults, forwarded);
 
   return headers;
 }

--- a/src/routes/bluesky.js
+++ b/src/routes/bluesky.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials, setAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const BSKY_API = 'https://bsky.social/xrpc';
@@ -155,7 +156,7 @@ async function getAccessToken(accountName) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const accessToken = await getAccessToken(accountName);
   if (!accessToken) {
     return { status: 401, data: { error: 'Bluesky account not configured', message: `Set up Bluesky account "${accountName}" in the admin UI` } };
@@ -170,11 +171,13 @@ export async function readService(accountName, path, { query = {}, raw = false }
   const queryString = new URLSearchParams(query).toString();
   const url = `${BSKY_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${accessToken}`,
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   let data = await response.json();
@@ -197,7 +200,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Bluesky API request failed', message: error.message });

--- a/src/routes/brave.js
+++ b/src/routes/brave.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const BRAVE_API = 'https://api.search.brave.com/res/v1';
@@ -67,7 +68,7 @@ const BRAVE_SIMPLIFIERS = {
 };
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const creds = getAccountCredentials('brave', accountName);
   if (!creds?.api_key) {
     return { status: 401, data: { error: 'Brave Search API key not configured', hint: `Configure API key for account "${accountName}" in the AgentGate UI` } };
@@ -76,11 +77,13 @@ export async function readService(accountName, path, { query = {}, raw = false }
   const queryString = new URLSearchParams(query).toString();
   const url = `${BRAVE_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Accept': 'application/json',
+    'X-Subscription-Token': creds.api_key
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Accept': 'application/json',
-      'X-Subscription-Token': creds.api_key
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   let data = await response.json();
@@ -100,7 +103,7 @@ router.get('/:accountName/web/search', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, 'web/search', { query: req.query, raw });
+    const result = await readService(req.params.accountName, 'web/search', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Brave Search API request failed', message: error.message });
@@ -112,7 +115,7 @@ router.get('/:accountName/images/search', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, 'images/search', { query: req.query, raw });
+    const result = await readService(req.params.accountName, 'images/search', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Brave Search API request failed', message: error.message });
@@ -124,7 +127,7 @@ router.get('/:accountName/news/search', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, 'news/search', { query: req.query, raw });
+    const result = await readService(req.params.accountName, 'news/search', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Brave Search API request failed', message: error.message });

--- a/src/routes/calendar.js
+++ b/src/routes/calendar.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials, setAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const GOOGLE_API = 'https://www.googleapis.com/calendar/v3';
@@ -75,7 +76,7 @@ async function getAccessToken(accountName) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw: _raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw: _raw = false, reqHeaders = {} } = {}) {
   const accessToken = await getAccessToken(accountName);
   if (!accessToken) {
     return { status: 401, data: { error: 'Google Calendar account not configured', message: `Set up Google Calendar account "${accountName}" in the admin UI` } };
@@ -84,11 +85,13 @@ export async function readService(accountName, path, { query = {}, raw: _raw = f
   const queryString = new URLSearchParams(query).toString();
   const url = `${GOOGLE_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${accessToken}`,
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   const data = await response.json();
@@ -100,7 +103,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Google Calendar API request failed', message: error.message });

--- a/src/routes/fitbit.js
+++ b/src/routes/fitbit.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials, setAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const FITBIT_API = 'https://api.fitbit.com';
@@ -144,7 +145,7 @@ function getSimplifier(path) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const accessToken = await getAccessToken(accountName);
   if (!accessToken) {
     return { status: 401, data: { error: 'Fitbit account not configured', message: `Set up Fitbit account "${accountName}" in the admin UI` } };
@@ -153,11 +154,13 @@ export async function readService(accountName, path, { query = {}, raw = false }
   const queryString = new URLSearchParams(query).toString();
   const url = `${FITBIT_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${accessToken}`,
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   let data = await response.json();
@@ -177,7 +180,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Fitbit API request failed', message: error.message });

--- a/src/routes/github.js
+++ b/src/routes/github.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const GITHUB_API = 'https://api.github.com';
@@ -92,19 +93,21 @@ function getSimplifier(path) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const queryString = new URLSearchParams(query).toString();
   const url = `${GITHUB_API}/${path}${queryString ? '?' + queryString : ''}`;
 
-  const headers = {
+  const defaults = {
     'Accept': 'application/vnd.github+json',
     'User-Agent': 'agentgate-gateway'
   };
 
   const creds = getAccountCredentials('github', accountName);
   if (creds?.token) {
-    headers['Authorization'] = `Bearer ${creds.token}`;
+    defaults['Authorization'] = `Bearer ${creds.token}`;
   }
+
+  const headers = mergeHeaders(defaults, getForwardableHeaders(reqHeaders));
 
   const response = await fetch(url, { headers });
   let data = await response.json();
@@ -124,7 +127,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'GitHub API request failed', message: error.message });

--- a/src/routes/google-search.js
+++ b/src/routes/google-search.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const GOOGLE_SEARCH_API = 'https://www.googleapis.com/customsearch/v1';
@@ -33,7 +34,7 @@ export const serviceInfo = {
 };
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const { q, searchType, start, num, ...otherParams } = query;
 
   if (!q) {
@@ -55,7 +56,9 @@ export async function readService(accountName, path, { query = {}, raw = false }
 
   const url = `${GOOGLE_SEARCH_API}?${params.toString()}`;
 
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    headers: mergeHeaders({}, getForwardableHeaders(reqHeaders))
+  });
   let data = await response.json();
 
   if (!raw && response.ok) {
@@ -70,7 +73,7 @@ router.get('/:accountName/search', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, 'search', { query: req.query, raw });
+    const result = await readService(req.params.accountName, 'search', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Google Search API request failed', message: error.message });

--- a/src/routes/jira.js
+++ b/src/routes/jira.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 
@@ -83,7 +84,7 @@ function getSimplifier(path) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const config = getJiraConfig(accountName);
   if (!config) {
     return { status: 401, data: { error: 'Jira account not configured', message: `Set up Jira account "${accountName}" in the admin UI` } };
@@ -94,11 +95,13 @@ export async function readService(accountName, path, { query = {}, raw = false }
 
   const basicAuth = Buffer.from(`${config.email}:${config.apiToken}`).toString('base64');
 
+  const defaults = {
+    'Authorization': `Basic ${basicAuth}`,
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Basic ${basicAuth}`,
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   let data = await response.json();
@@ -118,7 +121,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Jira API request failed', message: error.message });

--- a/src/routes/linkedin.js
+++ b/src/routes/linkedin.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials, setAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const LINKEDIN_API = 'https://api.linkedin.com/v2';
@@ -88,7 +89,7 @@ async function getAccessToken(accountName) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw: _raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw: _raw = false, reqHeaders = {} } = {}) {
   const accessToken = await getAccessToken(accountName);
   if (!accessToken) {
     return { status: 401, data: { error: 'LinkedIn account not configured', message: `Set up LinkedIn account "${accountName}" in the admin UI` } };
@@ -103,13 +104,15 @@ export async function readService(accountName, path, { query = {}, raw: _raw = f
   const queryString = new URLSearchParams(query).toString();
   const url = `${LINKEDIN_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${accessToken}`,
+    'LinkedIn-Version': '202401',
+    'X-Restli-Protocol-Version': '2.0.0',
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'LinkedIn-Version': '202401',
-      'X-Restli-Protocol-Version': '2.0.0',
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   const data = await response.json();
@@ -121,7 +124,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'LinkedIn API request failed', message: error.message });

--- a/src/routes/mastodon.js
+++ b/src/routes/mastodon.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 
@@ -93,7 +94,7 @@ function getSimplifier(path) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw = false, reqHeaders = {} } = {}) {
   const config = getMastodonConfig(accountName);
   if (!config) {
     return { status: 401, data: { error: 'Mastodon account not configured', message: `Set up Mastodon account "${accountName}" in the admin UI` } };
@@ -108,11 +109,13 @@ export async function readService(accountName, path, { query = {}, raw = false }
   const queryString = new URLSearchParams(query).toString();
   const url = `https://${config.instance}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${config.accessToken}`,
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${config.accessToken}`,
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   let data = await response.json();
@@ -132,7 +135,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Mastodon API request failed', message: error.message });

--- a/src/routes/reddit.js
+++ b/src/routes/reddit.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials, setAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const REDDIT_API = 'https://oauth.reddit.com';
@@ -82,7 +83,7 @@ async function getAccessToken(accountName) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw: _raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw: _raw = false, reqHeaders = {} } = {}) {
   const accessToken = await getAccessToken(accountName);
   if (!accessToken) {
     return { status: 401, data: { error: 'Reddit account not configured', message: `Set up Reddit account "${accountName}" in the admin UI` } };
@@ -97,11 +98,13 @@ export async function readService(accountName, path, { query = {}, raw: _raw = f
   const queryString = new URLSearchParams(query).toString();
   const url = `${REDDIT_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${accessToken}`,
+    'User-Agent': 'agentgate-gateway/1.0'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'User-Agent': 'agentgate-gateway/1.0'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   const data = await response.json();
@@ -113,7 +116,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'Reddit API request failed', message: error.message });

--- a/src/routes/youtube.js
+++ b/src/routes/youtube.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getAccountCredentials, setAccountCredentials } from '../lib/db.js';
+import { getForwardableHeaders, mergeHeaders } from '../lib/headerUtils.js';
 
 const router = Router();
 const YOUTUBE_API = 'https://www.googleapis.com/youtube/v3';
@@ -74,7 +75,7 @@ async function getAccessToken(accountName) {
 }
 
 // Core read function - used by both Express routes and MCP
-export async function readService(accountName, path, { query = {}, raw: _raw = false } = {}) {
+export async function readService(accountName, path, { query = {}, raw: _raw = false, reqHeaders = {} } = {}) {
   const accessToken = await getAccessToken(accountName);
   if (!accessToken) {
     return { status: 401, data: { error: 'YouTube account not configured', message: `Set up YouTube account "${accountName}" in the admin UI` } };
@@ -83,11 +84,13 @@ export async function readService(accountName, path, { query = {}, raw: _raw = f
   const queryString = new URLSearchParams(query).toString();
   const url = `${YOUTUBE_API}/${path}${queryString ? '?' + queryString : ''}`;
 
+  const defaults = {
+    'Authorization': `Bearer ${accessToken}`,
+    'Accept': 'application/json'
+  };
+
   const response = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Accept': 'application/json'
-    }
+    headers: mergeHeaders(defaults, getForwardableHeaders(reqHeaders))
   });
 
   const data = await response.json();
@@ -99,7 +102,7 @@ router.get('/:accountName/*', async (req, res) => {
   try {
     const rawHeader = req.headers['x-agentgate-raw'];
     const raw = rawHeader !== undefined ? rawHeader === 'true' : !!(req.apiKeyInfo?.raw_results);
-    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw });
+    const result = await readService(req.params.accountName, req.params[0] || '', { query: req.query, raw, reqHeaders: req.headers });
     res.status(result.status).json(result.data);
   } catch (error) {
     res.status(500).json({ error: 'YouTube API request failed', message: error.message });


### PR DESCRIPTION
## Issue
Closes #282

## Changes
- New `src/lib/headerUtils.js` with `getForwardableHeaders()` and `mergeHeaders()`
- All 11 service routes updated to forward agent-provided headers
- `queueExecutor.js` `buildHeaders()` updated for write path
- Agent headers override service defaults; credentials always from stored creds
- Backward compatible (reqHeaders defaults to {})

## Tests
```
Test Suites: 5 passed, 5 total
Tests: 70 passed, 5 skipped
Lint: 0 errors
```