### PR TITLE
fix: emoji dialog no longer pops up automatically on approve (#284)

### DIFF
--- a/views/pages/queue.ejs
+++ b/views/pages/queue.ejs
@@ -129,7 +129,7 @@
         <div class="emoji-section" id="emoji-section-<%= entry.id %>">
           <% if (entry.reaction_emoji) { %>
             <span class="reaction-emoji-display" data-id="<%= entry.id %>" title="Click to change"><%- escapeHtml(entry.reaction_emoji) %></span>
-            <div class="emoji-picker-popup d-none" id="emoji-popup-<%= entry.id %>">
+            <div class="emoji-picker-popup" id="emoji-popup-<%= entry.id %>" style="display:none">
               <% allEmojis.forEach(function(e) { %>
                 <button type="button" class="emoji-btn" data-id="<%= entry.id %>" data-emoji="<%= e %>"><%= e %></button>
               <% }); %>
@@ -137,7 +137,7 @@
             </div>
           <% } else { %>
             <button type="button" class="emoji-trigger" data-id="<%= entry.id %>" title="Add reaction"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#737373" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg></button>
-            <div class="emoji-picker-popup d-none" id="emoji-popup-<%= entry.id %>">
+            <div class="emoji-picker-popup" id="emoji-popup-<%= entry.id %>" style="display:none">
               <% allEmojis.forEach(function(e) { %>
                 <button type="button" class="emoji-btn" data-id="<%= entry.id %>" data-emoji="<%= e %>"><%= e %></button>
               <% }); %>
@@ -372,7 +372,7 @@
       return '<button type="button" class="emoji-btn" data-id="'+id+'" data-emoji="'+e+'">'+e+'</button>';
     }).join('');
     if (includeRemove) btns += '<button type="button" class="emoji-btn emoji-remove" data-id="'+id+'" data-emoji="" title="Remove">✕</button>';
-    return '<div class="emoji-picker-popup d-none" id="emoji-popup-'+id+'">'+btns+'</div>';
+    return '<div class="emoji-picker-popup" id="emoji-popup-'+id+'" style="display:none">'+btns+'</div>';
   }
 
   async function setReaction(id, emoji) {


### PR DESCRIPTION
## Fix
Emoji picker popup was appearing immediately when approving a queue request.

**Root cause:** The popup divs used Bootstrap's `d-none` class to hide, but the JS toggle (`toggleEmojiPicker`) uses `style.display`. When `updateEntryStatus()` dynamically inserts the emoji section after approval, the new popup has `d-none` but no inline style — so it shows immediately.

**Fix:** Replace `class="d-none"` with `style="display:none"` on all 3 emoji-picker-popup divs (2 server-rendered EJS + 1 JS-generated in `emojiPickerHtml()`).

Closes #284

## Tests
```
Test Suites: 5 passed, 5 total
Tests:       5 skipped, 70 passed, 75 total
Lint: clean
```

@Luthien — requesting review