### PR TITLE
feat: Google Gemini provider translation layer (#262)

### DIFF
--- a/src/lib/geminiTranslator.js
+++ b/src/lib/geminiTranslator.js
@@ -1,0 +1,162 @@
+// Gemini ↔ OpenAI translation layer
+// Translates OpenAI-format requests/responses to/from Google Gemini API
+
+/**
+ * Translate an OpenAI chat completion request body to Gemini format.
+ * The model is used in the URL path, not in the body.
+ */
+export function translateRequest(openaiBody) {
+  const { messages = [], ...rest } = openaiBody;
+
+  // Extract system messages → systemInstruction
+  const systemMessages = messages.filter(m => m.role === 'system');
+  const nonSystemMessages = messages.filter(m => m.role !== 'system');
+
+  const geminiBody = {};
+
+  if (systemMessages.length > 0) {
+    const systemText = systemMessages.map(m => m.content).join('\n');
+    geminiBody.systemInstruction = { parts: [{ text: systemText }] };
+  }
+
+  // Convert messages → contents (assistant → model)
+  geminiBody.contents = nonSystemMessages.map(m => ({
+    role: m.role === 'assistant' ? 'model' : m.role,
+    parts: [{ text: m.content || '' }]
+  }));
+
+  // Build generationConfig from OpenAI params
+  const generationConfig = {};
+  if (rest.max_tokens !== undefined) generationConfig.maxOutputTokens = rest.max_tokens;
+  if (rest.temperature !== undefined) generationConfig.temperature = rest.temperature;
+  if (rest.top_p !== undefined) generationConfig.topP = rest.top_p;
+  if (rest.stop !== undefined) {
+    generationConfig.stopSequences = Array.isArray(rest.stop) ? rest.stop : [rest.stop];
+  }
+
+  if (Object.keys(generationConfig).length > 0) {
+    geminiBody.generationConfig = generationConfig;
+  }
+
+  return geminiBody;
+}
+
+/**
+ * Build the upstream URL for Gemini requests.
+ */
+export function buildGeminiUrl(baseUrl, model, isStreaming) {
+  const base = baseUrl.replace(/\/+$/, '');
+  if (isStreaming) {
+    return `${base}/v1/models/${model}:streamGenerateContent?alt=sse`;
+  }
+  return `${base}/v1/models/${model}:generateContent`;
+}
+
+/**
+ * Map Gemini finishReason to OpenAI finish_reason.
+ */
+function mapFinishReason(reason) {
+  switch (reason) {
+  case 'STOP': return 'stop';
+  case 'MAX_TOKENS': return 'length';
+  case 'SAFETY': return 'content_filter';
+  default: return reason ? reason.toLowerCase() : 'stop';
+  }
+}
+
+/**
+ * Translate a Gemini response to OpenAI chat completion format.
+ */
+export function translateResponse(geminiRes, model) {
+  const candidate = geminiRes.candidates?.[0];
+  const content = candidate?.content?.parts?.[0]?.text || '';
+  const promptTokens = geminiRes.usageMetadata?.promptTokenCount || 0;
+  const completionTokens = geminiRes.usageMetadata?.candidatesTokenCount || 0;
+
+  return {
+    id: `chatcmpl-${Date.now()}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: model || 'gemini',
+    choices: [{
+      index: 0,
+      message: { role: 'assistant', content },
+      finish_reason: mapFinishReason(candidate?.finishReason)
+    }],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens
+    }
+  };
+}
+
+/**
+ * Transform a Gemini SSE stream into OpenAI-format SSE chunks.
+ */
+export async function translateStream(upstreamRes, res, model) {
+  const reader = upstreamRes.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let sentRole = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop(); // keep incomplete line
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const dataStr = line.slice(6).trim();
+        if (!dataStr) continue;
+
+        let data;
+        try { data = JSON.parse(dataStr); } catch { continue; }
+
+        const candidate = data.candidates?.[0];
+        if (!candidate) continue;
+
+        const text = candidate.content?.parts?.[0]?.text;
+        const finishReason = candidate.finishReason;
+
+        if (text !== undefined) {
+          const delta = { content: text };
+          if (!sentRole) {
+            delta.role = 'assistant';
+            sentRole = true;
+          }
+          writeSSE(res, {
+            id: `chatcmpl-${Date.now()}`,
+            object: 'chat.completion.chunk',
+            created: Math.floor(Date.now() / 1000),
+            model: model || 'gemini',
+            choices: [{ index: 0, delta, finish_reason: null }]
+          });
+        }
+
+        if (finishReason && finishReason !== 'FINISH_REASON_UNSPECIFIED') {
+          writeSSE(res, {
+            id: `chatcmpl-${Date.now()}`,
+            object: 'chat.completion.chunk',
+            created: Math.floor(Date.now() / 1000),
+            model: model || 'gemini',
+            choices: [{ index: 0, delta: {}, finish_reason: mapFinishReason(finishReason) }]
+          });
+          res.write('data: [DONE]\n\n');
+        }
+      }
+    }
+  } catch (streamErr) {
+    if (streamErr.name !== 'AbortError') {
+      console.error('[gemini-translator] Stream error:', streamErr.message);
+    }
+  }
+}
+
+function writeSSE(res, obj) {
+  res.write(`data: ${JSON.stringify(obj)}\n\n`);
+}

--- a/src/routes/llm.js
+++ b/src/routes/llm.js
@@ -2,6 +2,7 @@
 import { Router } from 'express';
 import { getLlmProvider, getAgentLlmConfig, listAgentModels } from '../lib/db.js';
 import { translateRequest, translateResponse, translateStream } from '../lib/anthropicTranslator.js';
+import { translateRequest as geminiTranslateRequest, translateResponse as geminiTranslateResponse, translateStream as geminiTranslateStream, buildGeminiUrl } from '../lib/geminiTranslator.js';
 
 const router = Router();
 
@@ -30,6 +31,9 @@ function buildUpstreamHeaders(provider, originalHeaders) {
   case 'anthropic':
     headers['x-api-key'] = provider.api_key;
     headers['anthropic-version'] = originalHeaders['anthropic-version'] || '2023-06-01';
+    break;
+  case 'google':
+    headers['x-goog-api-key'] = provider.api_key;
     break;
   case 'openai':
   default:
@@ -75,9 +79,8 @@ router.post('/v1/chat/completions', async (req, res) => {
 
     // Build upstream request
     const isAnthropic = provider.provider_type === 'anthropic';
+    const isGemini = provider.provider_type === 'google';
     const baseUrl = provider.base_url || PROVIDER_DEFAULTS[provider.provider_type] || provider.base_url;
-    const endpoint = isAnthropic ? '/v1/messages' : '/v1/chat/completions';
-    const upstreamUrl = `${baseUrl.replace(/\/+$/, '')}${endpoint}`;
     const upstreamHeaders = buildUpstreamHeaders(provider, req.headers);
 
     // Override model if agent has a specific model assigned
@@ -86,12 +89,20 @@ router.post('/v1/chat/completions', async (req, res) => {
       body.model = config.model_id;
     }
 
-    // Translate request for Anthropic providers
-    if (isAnthropic) {
-      body = translateRequest(body);
-    }
-
     const isStreaming = body.stream === true;
+    const modelForUrl = body.model;
+
+    // Build URL and translate body based on provider
+    let upstreamUrl;
+    if (isAnthropic) {
+      upstreamUrl = `${baseUrl.replace(/\/+$/, '')}/v1/messages`;
+      body = translateRequest(body);
+    } else if (isGemini) {
+      upstreamUrl = buildGeminiUrl(baseUrl, modelForUrl, isStreaming);
+      body = geminiTranslateRequest(body);
+    } else {
+      upstreamUrl = `${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`;
+    }
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
@@ -121,6 +132,10 @@ router.post('/v1/chat/completions', async (req, res) => {
         if (isAnthropic) {
           // Translate Anthropic SSE → OpenAI SSE
           await translateStream(upstreamRes, res);
+          res.end();
+        } else if (isGemini) {
+          // Translate Gemini SSE → OpenAI SSE
+          await geminiTranslateStream(upstreamRes, res, modelForUrl);
           res.end();
         } else {
           // Pipe OpenAI-compatible stream directly
@@ -152,6 +167,16 @@ router.post('/v1/chat/completions', async (req, res) => {
           try {
             const anthropicJson = JSON.parse(responseBody);
             const openaiJson = translateResponse(anthropicJson);
+            res.json(openaiJson);
+          } catch {
+            // If parsing fails, forward as-is
+            res.send(responseBody);
+          }
+        } else if (isGemini) {
+          // Translate Gemini JSON → OpenAI format
+          try {
+            const geminiJson = JSON.parse(responseBody);
+            const openaiJson = geminiTranslateResponse(geminiJson, modelForUrl);
             res.json(openaiJson);
           } catch {
             // If parsing fails, forward as-is

--- a/tests/geminiTranslator.test.js
+++ b/tests/geminiTranslator.test.js
@@ -1,0 +1,119 @@
+import { translateRequest, translateResponse, buildGeminiUrl } from '../src/lib/geminiTranslator.js';
+
+describe('geminiTranslator', () => {
+  describe('translateRequest', () => {
+    it('converts messages with system extraction', () => {
+      const result = translateRequest({
+        model: 'gemini-2.0-flash',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi there' },
+          { role: 'user', content: 'How are you?' }
+        ],
+        max_tokens: 1000,
+        temperature: 0.7,
+        top_p: 0.9,
+        stop: ['END']
+      });
+
+      expect(result.systemInstruction).toEqual({ parts: [{ text: 'You are helpful.' }] });
+      expect(result.contents).toHaveLength(3);
+      expect(result.contents[0].role).toBe('user');
+      expect(result.contents[1].role).toBe('model'); // assistant → model
+      expect(result.contents[2].role).toBe('user');
+      expect(result.generationConfig.maxOutputTokens).toBe(1000);
+      expect(result.generationConfig.temperature).toBe(0.7);
+      expect(result.generationConfig.topP).toBe(0.9);
+      expect(result.generationConfig.stopSequences).toEqual(['END']);
+      expect(result.model).toBeUndefined(); // model not in body
+    });
+
+    it('omits systemInstruction when no system messages', () => {
+      const result = translateRequest({
+        model: 'gemini-2.0-flash',
+        messages: [{ role: 'user', content: 'Hi' }]
+      });
+      expect(result.systemInstruction).toBeUndefined();
+      expect(result.contents).toHaveLength(1);
+    });
+
+    it('omits generationConfig when no params', () => {
+      const result = translateRequest({
+        model: 'gemini-2.0-flash',
+        messages: [{ role: 'user', content: 'Hi' }]
+      });
+      expect(result.generationConfig).toBeUndefined();
+    });
+
+    it('handles stop as string', () => {
+      const result = translateRequest({
+        model: 'gemini-2.0-flash',
+        messages: [{ role: 'user', content: 'Hi' }],
+        stop: 'STOP'
+      });
+      expect(result.generationConfig.stopSequences).toEqual(['STOP']);
+    });
+  });
+
+  describe('translateResponse', () => {
+    it('converts Gemini response to OpenAI format', () => {
+      const result = translateResponse({
+        candidates: [{
+          content: { parts: [{ text: 'Hello!' }] },
+          finishReason: 'STOP'
+        }],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 5
+        }
+      }, 'gemini-2.0-flash');
+
+      expect(result.object).toBe('chat.completion');
+      expect(result.model).toBe('gemini-2.0-flash');
+      expect(result.choices[0].message.content).toBe('Hello!');
+      expect(result.choices[0].message.role).toBe('assistant');
+      expect(result.choices[0].finish_reason).toBe('stop');
+      expect(result.usage.prompt_tokens).toBe(10);
+      expect(result.usage.completion_tokens).toBe(5);
+      expect(result.usage.total_tokens).toBe(15);
+    });
+
+    it('maps MAX_TOKENS finish reason', () => {
+      const result = translateResponse({
+        candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'MAX_TOKENS' }]
+      }, 'gemini-2.0-flash');
+      expect(result.choices[0].finish_reason).toBe('length');
+    });
+
+    it('maps SAFETY finish reason', () => {
+      const result = translateResponse({
+        candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }]
+      }, 'gemini-2.0-flash');
+      expect(result.choices[0].finish_reason).toBe('content_filter');
+    });
+
+    it('handles missing fields gracefully', () => {
+      const result = translateResponse({}, 'gemini-2.0-flash');
+      expect(result.choices[0].message.content).toBe('');
+      expect(result.usage.prompt_tokens).toBe(0);
+    });
+  });
+
+  describe('buildGeminiUrl', () => {
+    it('builds non-streaming URL', () => {
+      const url = buildGeminiUrl('https://generativelanguage.googleapis.com', 'gemini-2.0-flash', false);
+      expect(url).toBe('https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash:generateContent');
+    });
+
+    it('builds streaming URL', () => {
+      const url = buildGeminiUrl('https://generativelanguage.googleapis.com', 'gemini-2.0-flash', true);
+      expect(url).toBe('https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash:streamGenerateContent?alt=sse');
+    });
+
+    it('strips trailing slashes from base URL', () => {
+      const url = buildGeminiUrl('https://example.com/', 'model', false);
+      expect(url).toBe('https://example.com/v1/models/model:generateContent');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds Google Gemini as a supported LLM provider in the proxy, translating OpenAI-format requests/responses to/from the Gemini API.

## Changes
- **`src/lib/geminiTranslator.js`** (new) — Request, response, and SSE stream translation
- **`src/routes/llm.js`** — Branch on `provider_type === google`, Gemini URL building, `x-goog-api-key` header
- **`tests/geminiTranslator.test.js`** (new) — 11 tests covering request translation, response translation, URL building

## Translation Details
- System messages → `systemInstruction`
- `assistant` role → `model` role
- `max_tokens` → `generationConfig.maxOutputTokens`
- Model name goes in URL path, not body
- Finish reason mapping: STOP→stop, MAX_TOKENS→length, SAFETY→content_filter
- SSE stream: Gemini chunks → OpenAI delta format + [DONE]

## Test Results
```
Test Suites: 6 passed, 6 total
Tests: 5 skipped, 81 passed, 86 total
Lint: clean
```

Reviewer: @Luthien