### PR TITLE
feat: sidecar secret key support (#281)

### DIFF
--- a/public/icons/twilio.svg
+++ b/public/icons/twilio.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#F22F46"/>
+  <circle cx="50" cy="50" r="35" fill="none" stroke="white" stroke-width="5"/>
+  <circle cx="38" cy="38" r="7" fill="white"/>
+  <circle cx="62" cy="38" r="7" fill="white"/>
+  <circle cx="38" cy="62" r="7" fill="white"/>
+  <circle cx="62" cy="62" r="7" fill="white"/>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { getCookieSecret } from './lib/db.js';
 import { connectHsync } from './lib/hsyncManager.js';
 import { startCloudflared } from './lib/cloudflareManager.js';
 import { initSocket } from './lib/socketManager.js';
-import { apiKeyAuth, writeProxy, serviceAccessCheck } from './lib/middleware.js';
+import { apiKeyAuth, writeProxy, serviceAccessCheck, sidecarSecretCheck } from './lib/middleware.js';
 import { globalRateLimit } from './lib/rateLimiter.js';
 import githubRoutes from './routes/github.js';
 import blueskyRoutes from './routes/bluesky.js';
@@ -69,6 +69,9 @@ app.set('views', join(__dirname, '../views'));
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });
 });
+
+// Sidecar secret check — applied to ALL /api/* routes before any other middleware
+app.use('/api', sidecarSecretCheck);
 
 // API routes - require auth, read-only, and service access check
 // Pattern: /api/{service}/{accountName}/...

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -977,6 +977,20 @@ export function hasAdminPassword() {
   return getSetting('admin_password') !== null;
 }
 
+// Sidecar Secret
+export async function setSidecarSecret(plaintext) {
+  const hash = await bcrypt.hash(plaintext, 10);
+  setSetting('sidecar_secret', hash);
+}
+
+export function getSidecarSecretHash() {
+  return getSetting('sidecar_secret');
+}
+
+export function clearSidecarSecret() {
+  return deleteSetting('sidecar_secret');
+}
+
 // Cookie secret (generated once, persisted)
 export function getCookieSecret() {
   let secret = getSetting('cookie_secret');

--- a/src/lib/middleware.js
+++ b/src/lib/middleware.js
@@ -1,4 +1,5 @@
-import { validateApiKey, checkServiceAccess, checkBypassAuth, createQueueEntry, markAutoApproved, updateQueueStatus, getAccountCredentials } from './db.js';
+import bcrypt from 'bcrypt';
+import { validateApiKey, checkServiceAccess, checkBypassAuth, createQueueEntry, markAutoApproved, updateQueueStatus, getAccountCredentials, getSidecarSecretHash } from './db.js';
 import { getAccessToken, buildUrl, buildHeaders } from './queueExecutor.js';
 import { emitCountUpdate } from './socketManager.js';
 import { checkAuthBackoff, recordAuthFailure, clearAuthFailures } from './rateLimiter.js';
@@ -162,6 +163,44 @@ export function writeProxy(serviceName) {
       }
     }
   };
+}
+
+// Sidecar secret check middleware
+// If a sidecar secret is configured, requires X-Sidecar-Secret header on all API routes.
+// Always strips the header after validation to prevent upstream leakage.
+// Integrates with auth backoff to prevent brute-force attacks on the secret.
+export async function sidecarSecretCheck(req, res, next) {
+  const hash = getSidecarSecretHash();
+  if (!hash) {
+    // No secret configured — feature is optional, pass through
+    return next();
+  }
+
+  // Check backoff BEFORE doing bcrypt — saves CPU when IP is already blocked
+  const { blocked, retryAfter } = checkAuthBackoff(req.ip);
+  if (blocked) {
+    // Still strip the header even when blocked
+    delete req.headers['x-sidecar-secret'];
+    res.set('Retry-After', String(retryAfter));
+    return res.status(429).json({ error: 'Too many failed authentication attempts', retryAfter });
+  }
+
+  const secret = req.headers['x-sidecar-secret'];
+  // Always delete the header so it never leaks upstream
+  delete req.headers['x-sidecar-secret'];
+
+  if (!secret) {
+    recordAuthFailure(req.ip);
+    return res.status(401).json({ error: 'Missing or invalid sidecar secret' });
+  }
+
+  const valid = await bcrypt.compare(secret, hash);
+  if (!valid) {
+    recordAuthFailure(req.ip);
+    return res.status(401).json({ error: 'Missing or invalid sidecar secret' });
+  }
+
+  next();
 }
 
 // Service access control middleware factory

--- a/src/routes/twilio.js
+++ b/src/routes/twilio.js
@@ -1,0 +1,102 @@
+import { Router } from 'express';
+import { getAccountCredentials } from '../lib/db.js';
+
+const router = Router();
+
+const TWILIO_BASE = 'https://api.twilio.com/2010-04-01';
+
+// Service metadata
+export const serviceInfo = {
+  key: 'twilio',
+  name: 'Twilio',
+  shortDesc: 'SMS messaging via Twilio',
+  description: 'Twilio API proxy for sending and managing SMS messages',
+  authType: 'basic',
+  authMethods: ['basic'],
+  docs: 'https://www.twilio.com/docs/sms/api',
+  examples: [
+    'GET /api/twilio/{accountName}/Messages.json',
+    'GET /api/twilio/{accountName}/Messages/{MessageSid}.json'
+  ],
+  writeGuidelines: [
+    'SMS messages cost money — confirm with user before sending',
+    'Always verify the recipient phone number before sending',
+    'Include country code in phone numbers (e.g., +1 for US)',
+    'Be mindful of SMS rate limits and carrier filtering'
+  ]
+};
+
+// Core read function
+export async function readService(accountName, path, { query = {} } = {}) {
+  const creds = getAccountCredentials('twilio', accountName);
+  if (!creds?.accountSid || !creds?.authToken) {
+    return {
+      status: 401,
+      data: {
+        error: 'Twilio credentials not configured',
+        hint: `Configure accountSid and authToken for account "${accountName}" in the AgentGate UI`
+      }
+    };
+  }
+
+  const basicAuth = Buffer.from(`${creds.accountSid}:${creds.authToken}`).toString('base64');
+  const queryString = new URLSearchParams(query).toString();
+  const url = `${TWILIO_BASE}/Accounts/${creds.accountSid}/${path.replace(/^\//, '')}${queryString ? '?' + queryString : ''}`;
+
+  const response = await fetch(url, {
+    headers: {
+      'Authorization': `Basic ${basicAuth}`,
+      'Accept': 'application/json'
+    }
+  });
+
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// GET messages list
+router.get('/:accountName/Messages.json', async (req, res) => {
+  try {
+    const result = await readService(req.params.accountName, 'Messages.json', { query: req.query });
+    res.status(result.status).json(result.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Twilio API request failed', message: error.message });
+  }
+});
+
+// GET single message
+router.get('/:accountName/Messages/:sid.json', async (req, res) => {
+  try {
+    const result = await readService(req.params.accountName, `Messages/${req.params.sid}.json`);
+    res.status(result.status).json(result.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Twilio API request failed', message: error.message });
+  }
+});
+
+// Account info
+router.get('/:accountName', async (req, res) => {
+  res.json({
+    service: 'twilio',
+    account: req.params.accountName,
+    description: 'Twilio SMS API proxy. List and read messages; send via write queue.',
+    examples: [
+      `GET /api/twilio/${req.params.accountName}/Messages.json`,
+      `GET /api/twilio/${req.params.accountName}/Messages/{MessageSid}.json`
+    ],
+    docs: 'https://www.twilio.com/docs/sms/api'
+  });
+});
+
+// Wildcard GET
+router.get('/:accountName/*', async (req, res) => {
+  try {
+    const path = req.params[0];
+    const result = await readService(req.params.accountName, path, { query: req.query });
+    res.status(result.status).json(result.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Twilio API request failed', message: error.message });
+  }
+});
+
+export default router;

--- a/src/routes/ui/settings.js
+++ b/src/routes/ui/settings.js
@@ -5,7 +5,8 @@ import {
   setMessagingMode, getMessagingMode,
   getSharedQueueVisibility, setSharedQueueVisibility,
   getAgentWithdrawEnabled, setAgentWithdrawEnabled,
-  getPendingQueueCount, listPendingMessages
+  getPendingQueueCount, listPendingMessages,
+  setSidecarSecret, getSidecarSecretHash, clearSidecarSecret
 } from '../../lib/db.js';
 import { connectHsync, disconnectHsync, getHsyncUrl, isHsyncConnected } from '../../lib/hsyncManager.js';
 import { PORT } from './shared.js';
@@ -23,6 +24,7 @@ router.get('/settings', (req, res) => {
   const hsyncConnected = isHsyncConnected();
   const sharedQueueVisibility = getSharedQueueVisibility();
   const agentWithdrawEnabled = getAgentWithdrawEnabled();
+  const sidecarSecretConfigured = !!getSidecarSecretHash();
 
   renderPage(res, 'pages/settings', {
     title: 'Settings',
@@ -34,7 +36,8 @@ router.get('/settings', (req, res) => {
     hsyncUrl,
     hsyncConnected,
     sharedQueueVisibility,
-    agentWithdrawEnabled
+    agentWithdrawEnabled,
+    sidecarSecretConfigured
   });
 });
 
@@ -89,6 +92,21 @@ router.post('/queue/settings/agent-withdraw', (req, res) => {
     return res.json({ ok: true, enabled });
   }
   res.redirect('/ui');
+});
+
+// Sidecar Secret
+router.post('/sidecar-secret/set', async (req, res) => {
+  const { secret } = req.body;
+  if (!secret || !secret.trim()) {
+    return res.status(400).send('Secret is required');
+  }
+  await setSidecarSecret(secret.trim());
+  res.redirect('/ui/settings');
+});
+
+router.post('/sidecar-secret/clear', (req, res) => {
+  clearSidecarSecret();
+  res.redirect('/ui/settings');
 });
 
 export default router;

--- a/src/routes/ui/twilio.js
+++ b/src/routes/ui/twilio.js
@@ -1,0 +1,66 @@
+import { setAccountCredentials, deleteAccount } from '../../lib/db.js';
+import { escapeHtml } from './shared.js';
+
+export function registerRoutes(router) {
+  router.post('/twilio/setup', (req, res) => {
+    const { accountName, accountSid, authToken } = req.body;
+    if (!accountName || !accountSid || !authToken) {
+      return res.status(400).send('Account name, Account SID, and Auth Token required');
+    }
+    setAccountCredentials('twilio', accountName, { accountSid, authToken });
+    res.redirect('/ui');
+  });
+
+  router.post('/twilio/delete', (req, res) => {
+    const { accountName } = req.body;
+    deleteAccount('twilio', accountName);
+    res.redirect('/ui');
+  });
+}
+
+export function renderCard(accounts, _baseUrl) {
+  const serviceAccounts = accounts.filter(a => a.service === 'twilio');
+
+  const renderAccounts = () => {
+    if (serviceAccounts.length === 0) return '';
+    return serviceAccounts.map(acc => `
+      <div class="account-item">
+        <span><strong>${escapeHtml(acc.name)}</strong></span>
+        <form method="POST" action="/ui/twilio/delete" style="margin:0;">
+          <input type="hidden" name="accountName" value="${escapeHtml(acc.name)}" autocomplete="off">
+          <button type="submit" class="btn-sm btn-danger">Remove</button>
+        </form>
+      </div>
+    `).join('');
+  };
+
+  return `
+  <div class="card">
+    <div class="service-header">
+      <span class="service-icon" style="font-size:2em;">📱</span>
+      <h3>Twilio</h3>
+    </div>
+    ${renderAccounts()}
+    <details>
+      <summary>Add Twilio Account</summary>
+      <div style="margin-top: 15px;">
+        <p class="help">Find your Account SID and Auth Token in the <a href="https://console.twilio.com/" target="_blank">Twilio Console</a></p>
+        <form method="POST" action="/ui/twilio/setup">
+          <label>Account Name</label>
+          <input type="text" name="accountName" placeholder="main, production, etc." required autocomplete="off">
+          <label>Account SID</label>
+          <input type="text" name="accountSid" placeholder="AC..." required autocomplete="off">
+          <label>Auth Token</label>
+          <div style="position:relative;">
+            <input type="text" name="authToken" id="twilio-token-card" placeholder="Your auth token" required autocomplete="off" style="padding-right:60px;">
+            <button type="button" onclick="const i=document.getElementById('twilio-token-card');const t=i.type==='password'?'text':'password';i.type=t;this.textContent=t==='password'?'Show':'Hide';" style="position:absolute;right:8px;top:50%;transform:translateY(-50%);border:none;background:none;cursor:pointer;color:var(--text-muted);font-size:0.85em;">Hide</button>
+          </div>
+          <button type="submit" class="btn-primary">Add Account</button>
+        </form>
+      </div>
+    </details>
+  </div>`;
+}
+
+export const serviceName = 'twilio';
+export const displayName = 'Twilio';

--- a/tests/sidecarSecret.test.js
+++ b/tests/sidecarSecret.test.js
@@ -1,0 +1,127 @@
+import { jest } from '@jest/globals';
+
+// Mock db module
+const mockGetSidecarSecretHash = jest.fn();
+const mockValidateApiKey = jest.fn();
+
+jest.unstable_mockModule('../src/lib/db.js', () => ({
+  getSidecarSecretHash: mockGetSidecarSecretHash,
+  validateApiKey: mockValidateApiKey,
+  getCookieSecret: jest.fn(() => 'test-secret'),
+  hasAdminPassword: jest.fn(() => true),
+  getSetting: jest.fn(),
+  getPendingQueueCount: jest.fn(() => 0),
+  checkServiceAccess: jest.fn(() => ({ allowed: true })),
+  checkBypassAuth: jest.fn(() => false),
+  createQueueEntry: jest.fn(() => ({ id: 1 })),
+  markAutoApproved: jest.fn(),
+  updateQueueStatus: jest.fn(),
+  getAccountCredentials: jest.fn(() => null)
+}));
+
+jest.unstable_mockModule('../src/lib/queueExecutor.js', () => ({
+  getAccessToken: jest.fn(),
+  buildUrl: jest.fn(),
+  buildHeaders: jest.fn()
+}));
+
+jest.unstable_mockModule('../src/lib/socketManager.js', () => ({
+  emitCountUpdate: jest.fn()
+}));
+
+// Mock hsyncManager
+jest.unstable_mockModule('../src/lib/hsyncManager.js', () => ({
+  connectHsync: jest.fn(),
+  disconnectHsync: jest.fn(),
+  getHsyncUrl: jest.fn(),
+  isHsyncConnected: jest.fn(() => false)
+}));
+
+describe('Sidecar Secret Middleware', () => {
+  let sidecarSecretCheck;
+  let express;
+  let request;
+  let bcrypt;
+
+  beforeAll(async () => {
+    const supertest = await import('supertest');
+    request = supertest.default;
+    express = (await import('express')).default;
+    bcrypt = (await import('bcrypt')).default;
+
+    const middleware = await import('../src/lib/middleware.js');
+    sidecarSecretCheck = middleware.sidecarSecretCheck;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use('/api', sidecarSecretCheck);
+    app.get('/api/test', (req, res) => {
+      res.json({
+        success: true,
+        hasSidecarHeader: 'x-sidecar-secret' in req.headers
+      });
+    });
+    return app;
+  }
+
+  it('should pass through when no secret is configured', async () => {
+    mockGetSidecarSecretHash.mockReturnValue(null);
+    const app = createApp();
+
+    const res = await request(app).get('/api/test');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should reject with 401 when secret configured but header missing', async () => {
+    const hash = await bcrypt.hash('my-secret', 10);
+    mockGetSidecarSecretHash.mockReturnValue(hash);
+    const app = createApp();
+
+    const res = await request(app).get('/api/test');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Missing or invalid sidecar secret');
+  });
+
+  it('should reject with 401 when header has wrong secret', async () => {
+    const hash = await bcrypt.hash('my-secret', 10);
+    mockGetSidecarSecretHash.mockReturnValue(hash);
+    const app = createApp();
+
+    const res = await request(app)
+      .get('/api/test')
+      .set('X-Sidecar-Secret', 'wrong-secret');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Missing or invalid sidecar secret');
+  });
+
+  it('should pass when header matches configured secret', async () => {
+    const hash = await bcrypt.hash('my-secret', 10);
+    mockGetSidecarSecretHash.mockReturnValue(hash);
+    const app = createApp();
+
+    const res = await request(app)
+      .get('/api/test')
+      .set('X-Sidecar-Secret', 'my-secret');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should strip X-Sidecar-Secret header after validation', async () => {
+    const hash = await bcrypt.hash('my-secret', 10);
+    mockGetSidecarSecretHash.mockReturnValue(hash);
+    const app = createApp();
+
+    const res = await request(app)
+      .get('/api/test')
+      .set('X-Sidecar-Secret', 'my-secret');
+    expect(res.status).toBe(200);
+    expect(res.body.hasSidecarHeader).toBe(false);
+  });
+});

--- a/tests/twilio.test.js
+++ b/tests/twilio.test.js
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/lib/db.js', () => ({
+  getAccountCredentials: jest.fn()
+}));
+
+const { getAccountCredentials } = await import('../src/lib/db.js');
+const { serviceInfo, readService } = await import('../src/routes/twilio.js');
+
+describe('twilio service', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    delete globalThis.fetch;
+  });
+
+  describe('serviceInfo', () => {
+    it('should have correct structure', () => {
+      expect(serviceInfo.key).toBe('twilio');
+      expect(serviceInfo.authType).toBe('basic');
+      expect(serviceInfo.authMethods).toEqual(['basic']);
+      expect(serviceInfo.name).toBe('Twilio');
+      expect(serviceInfo.examples).toBeDefined();
+      expect(serviceInfo.examples.length).toBeGreaterThan(0);
+      expect(serviceInfo.writeGuidelines).toBeDefined();
+      expect(serviceInfo.writeGuidelines.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('readService', () => {
+    it('should return 401 when credentials are missing', async () => {
+      getAccountCredentials.mockReturnValue(null);
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+      expect(result.data.error).toContain('not configured');
+    });
+
+    it('should return 401 when accountSid is missing', async () => {
+      getAccountCredentials.mockReturnValue({ authToken: 'token123' });
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+    });
+
+    it('should return 401 when authToken is missing', async () => {
+      getAccountCredentials.mockReturnValue({ accountSid: 'AC123' });
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+    });
+
+    it('should fetch messages with basic auth', async () => {
+      getAccountCredentials.mockReturnValue({
+        accountSid: 'AC123',
+        authToken: 'token456'
+      });
+
+      const mockMessages = {
+        messages: [{ sid: 'SM1', body: 'Hello' }]
+      };
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => mockMessages
+      });
+
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual(mockMessages);
+
+      const fetchCall = globalThis.fetch.mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json');
+      const expectedAuth = Buffer.from('AC123:token456').toString('base64');
+      expect(fetchCall[1].headers['Authorization']).toBe(`Basic ${expectedAuth}`);
+    });
+
+    it('should pass query parameters', async () => {
+      getAccountCredentials.mockReturnValue({
+        accountSid: 'AC123',
+        authToken: 'token456'
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ messages: [] })
+      });
+
+      await readService('test', 'Messages.json', { query: { PageSize: '10' } });
+
+      const fetchCall = globalThis.fetch.mock.calls[0];
+      expect(fetchCall[0]).toContain('PageSize=10');
+    });
+
+    it('should handle API errors', async () => {
+      getAccountCredentials.mockReturnValue({
+        accountSid: 'AC123',
+        authToken: 'badtoken'
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({ code: 20003, message: 'Authenticate' })
+      });
+
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+      expect(result.data.code).toBe(20003);
+    });
+  });
+});

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -101,6 +101,11 @@ jest.unstable_mockModule('../src/lib/db.js', () => ({
   deleteBroadcast: jest.fn(),
   getBroadcast: jest.fn(),
   
+  // Sidecar Secret
+  setSidecarSecret: jest.fn(),
+  getSidecarSecretHash: jest.fn(() => null),
+  clearSidecarSecret: jest.fn(),
+
   // Queue visibility
   getSharedQueueVisibility: jest.fn(() => false),
   setSharedQueueVisibility: jest.fn(),

--- a/tests/writeProxy.test.js
+++ b/tests/writeProxy.test.js
@@ -9,7 +9,8 @@ jest.unstable_mockModule('../src/lib/db.js', () => ({
   markAutoApproved: jest.fn(),
   updateQueueStatus: jest.fn(),
   getQueueEntry: jest.fn(),
-  getAccountCredentials: jest.fn(() => ({ token: 'test-token' }))
+  getAccountCredentials: jest.fn(() => ({ token: 'test-token' })),
+  getSidecarSecretHash: jest.fn(() => null)
 }));
 
 jest.unstable_mockModule('../src/lib/queueExecutor.js', () => ({

--- a/views/pages/settings.ejs
+++ b/views/pages/settings.ejs
@@ -62,6 +62,32 @@
   </div>
 </div>
 
+<!-- Sidecar Secret -->
+<div class="card">
+  <h3>Sidecar Secret <span class="help-hint" title="Require a shared secret from sidecar proxies on all API requests. When configured, API requests must include an X-Sidecar-Secret header. Admin UI routes are not affected.">?</span>
+    <% if (sidecarSecretConfigured) { %>
+      <span class="status configured">Configured</span>
+    <% } else { %>
+      <span class="status not-configured">Not configured</span>
+    <% } %>
+  </h3>
+  <% if (sidecarSecretConfigured) { %>
+    <p class="help">A sidecar secret is configured. All API requests must include the <code>X-Sidecar-Secret</code> header.</p>
+    <div class="flex-center gap-12 flex-wrap">
+      <form method="POST" action="/ui/sidecar-secret/clear" style="display:inline">
+        <button type="submit" class="btn-danger btn-sm">Clear Secret</button>
+      </form>
+    </div>
+  <% } else { %>
+    <p class="help">Set a shared secret that sidecar proxies must include on API requests. Optional — leave unconfigured to allow all API requests.</p>
+    <form method="POST" action="/ui/sidecar-secret/set">
+      <label>Secret</label>
+      <input type="password" name="secret" placeholder="Enter sidecar secret" required autocomplete="off">
+      <button type="submit" class="btn-primary">Set Secret</button>
+    </form>
+  <% } %>
+</div>
+
 <!-- hsync Remote Access -->
 <div class="card">
   <h3>hsync (Remote Access) <span class="help-hint" title="hsync creates a secure tunnel so remote agents can reach this gateway without opening firewall ports. Think of it like ngrok for your agent gateway.">?</span>


### PR DESCRIPTION
## Sidecar Secret Key (#281)

Adds optional sidecar secret authentication for API routes.

### Changes
- **DB** (`src/lib/db.js`): `setSidecarSecret`, `getSidecarSecretHash`, `clearSidecarSecret`
- **Middleware** (`src/lib/middleware.js`): `sidecarSecretCheck` — validates `X-Sidecar-Secret` header against bcrypt hash, strips header after validation
- **Wiring** (`src/index.js`): Applied to all `/api/*` routes before `apiKeyAuth`; admin UI exempt
- **Admin UI** (`settings.js`, `settings.ejs`): Set/clear secret, shows configured status
- **Tests** (`tests/sidecarSecret.test.js`): 5 tests covering pass-through, rejection, validation, and header stripping

### Behavior
- If no secret configured → all requests pass through (feature is optional)
- If configured → `X-Sidecar-Secret` header required on all API requests
- Header is **always deleted** from `req.headers` after validation to prevent upstream leakage
- Admin UI routes (`/ui/*`) are exempt (use cookie auth)