### PR TITLE
feat: custom service plugins architecture (#247)

### DIFF
--- a/docs/PLUGINS_SECURITY.md
+++ b/docs/PLUGINS_SECURITY.md
@@ -1,0 +1,65 @@
+# Plugin Security & Trust Model
+
+## Overview
+
+AgentGate's plugin system loads and executes custom JavaScript modules from the filesystem at server startup. This document describes the trust boundaries and security considerations.
+
+## Trust Model
+
+**Installing a plugin is equivalent to granting it full server privileges.**
+
+Plugins are loaded via dynamic `import()` and run in the same Node.js process as AgentGate. A plugin has access to:
+
+- The full Node.js runtime (filesystem, network, child processes)
+- All environment variables (including API keys and secrets)
+- The Express app and all middleware
+- The AgentGate database (via imported modules)
+
+There is **no sandboxing** in v1. This is a deliberate design choice — sandboxing JavaScript in-process is complex and fragile, and plugins need access to Node.js APIs to be useful.
+
+## Protections
+
+### What AgentGate does protect against:
+
+1. **Authentication**: Plugin routes go through the same `apiKeyAuth` middleware as built-in services. Unauthenticated requests are rejected.
+
+2. **Write control**: Plugin routes use `writeProxy` middleware, so write operations (POST/PUT/PATCH/DELETE) go through the human-in-the-loop approval queue — same as built-in services.
+
+3. **Access control**: Plugin routes use `serviceAccessCheck` middleware, so per-agent service access restrictions apply.
+
+4. **Name collision prevention**: `registerPlugin()` checks that the plugin name doesn't collide with built-in services (`github`, `calendar`, etc.) or reserved API paths (`queue`, `agents`, `services`, etc.). A plugin named `github` or `agents` will be rejected at load time.
+
+5. **Manifest validation**: Plugin manifests are validated for required fields, name format (lowercase alphanumeric), and semver version format before loading.
+
+### What AgentGate does NOT protect against:
+
+1. **Malicious plugin code**: A plugin can read/write any file, make network requests, access environment variables, or modify the server's behavior in arbitrary ways.
+
+2. **Integrity verification**: There are no checksums, signatures, or allowlisting of plugin sources. Any code placed in the plugins directory will be loaded.
+
+3. **Runtime isolation**: Plugins share memory, event loop, and all resources with the main process. A plugin that blocks the event loop or crashes will affect the entire server.
+
+## Recommendations
+
+- **Only install plugins from trusted sources.** Treat plugin installation like installing a Node.js package with `--global` — it can do anything.
+- **Review plugin source code** before installing, especially `handler.js`/`handler.mjs`.
+- **Use a dedicated user** to run AgentGate if you install third-party plugins, to limit filesystem access.
+- **Monitor server logs** for unexpected behavior after installing plugins.
+
+## Plugin Directory
+
+Plugins are loaded from `~/.agentgate/plugins/` (or `AGENTGATE_PLUGINS_DIR` env var). Each plugin is a directory containing:
+
+```
+~/.agentgate/plugins/
+  my-plugin/
+    manifest.json    # Plugin metadata (name, version, auth config)
+    handler.mjs      # Plugin code (ESM module)
+```
+
+## Future Considerations
+
+- **Plugin signatures**: Verify plugin integrity via checksums or GPG signatures
+- **Permission declarations**: Manifest-declared capabilities (filesystem, network, etc.)
+- **Admin UI**: List loaded plugins, enable/disable without removing files
+- **Hot reload**: Load/unload plugins without server restart

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { connectHsync } from './lib/hsyncManager.js';
 import { startCloudflared } from './lib/cloudflareManager.js';
 import { initSocket } from './lib/socketManager.js';
 import { apiKeyAuth, writeProxy, serviceAccessCheck } from './lib/middleware.js';
+import { loadPlugins } from './lib/pluginLoader.js';
+import { registerPluginRoutes } from './lib/pluginRouter.js';
 import githubRoutes from './routes/github.js';
 import blueskyRoutes from './routes/bluesky.js';
 import redditRoutes from './routes/reddit.js';
@@ -129,39 +131,48 @@ app.get('/', (req, res) => {
   res.redirect('/ui');
 });
 
-const server = app.listen(PORT, async () => {
-  console.log(`Server running at: http://localhost:${PORT}`);
+// Load plugins and start server
+loadPlugins().then(() => {
+  // Register plugin routes after loading
+  registerPluginRoutes(app);
 
-  // Initialize socket.io for real-time updates
-  initSocket(server);
+  const server = app.listen(PORT, async () => {
+    console.log(`Server running at: http://localhost:${PORT}`);
 
-  // Set up WebSocket proxy for agent gateways (after socket.io)
-  setupWebSocketProxy(server);
+    // Initialize socket.io for real-time updates
+    initSocket(server);
 
-  // Set up channel WebSocket proxy for chat clients
-  setAdminTokenValidator(validateAdminChatToken);
-  setupHumanChannelProxy(server);
-  setupAgentChannelProxy(server);
+    // Set up WebSocket proxy for agent gateways (after socket.io)
+    setupWebSocketProxy(server);
 
-  // Start tunnels if configured
-  try {
-    await connectHsync(PORT);
-  } catch (err) {
-    console.error('hsync connection error:', err);
-  }
+    // Set up channel WebSocket proxy for chat clients
+    setAdminTokenValidator(validateAdminChatToken);
+    setupHumanChannelProxy(server);
+    setupAgentChannelProxy(server);
 
-  try {
-    startCloudflared();
-  } catch (err) {
-    console.error('cloudflared error:', err);
-  }
-});
+    // Start tunnels if configured
+    try {
+      await connectHsync(PORT);
+    } catch (err) {
+      console.error('hsync connection error:', err);
+    }
 
-server.on('error', (err) => {
-  if (err.code === 'EADDRINUSE') {
-    console.error(`Error: Port ${PORT} is already in use. Is another instance running?`);
-  } else {
-    console.error('Server error:', err.message);
-  }
+    try {
+      startCloudflared();
+    } catch (err) {
+      console.error('cloudflared error:', err);
+    }
+  });
+
+  server.on('error', (err) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`Error: Port ${PORT} is already in use. Is another instance running?`);
+    } else {
+      console.error('Server error:', err.message);
+    }
+    process.exit(1);
+  });
+}).catch((err) => {
+  console.error('Failed to load plugins:', err);
   process.exit(1);
 });

--- a/src/lib/pluginLoader.js
+++ b/src/lib/pluginLoader.js
@@ -1,0 +1,160 @@
+import { readdir, readFile, access } from 'fs/promises';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { homedir } from 'os';
+
+const DEFAULT_PLUGINS_DIR = join(homedir(), '.agentgate', 'plugins');
+const loadedPlugins = new Map();
+
+/**
+ * Validate a plugin manifest has required fields
+ * @param {object} manifest - Parsed manifest.json
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateManifest(manifest) {
+  const errors = [];
+  if (!manifest || typeof manifest !== 'object') {
+    return { valid: false, errors: ['Manifest must be a JSON object'] };
+  }
+  const requiredStrings = ['name', 'displayName', 'version'];
+  for (const field of requiredStrings) {
+    if (typeof manifest[field] !== 'string' || !manifest[field].trim()) {
+      errors.push(`Missing or invalid required field: ${field}`);
+    }
+  }
+  if (manifest.name && !/^[a-z0-9_-]+$/.test(manifest.name)) {
+    errors.push('name must be lowercase alphanumeric with hyphens/underscores only');
+  }
+  if (manifest.version && !/^\d+\.\d+\.\d+/.test(manifest.version)) {
+    errors.push('version must be semver (e.g. 1.0.0)');
+  }
+  if (manifest.auth !== undefined) {
+    if (typeof manifest.auth !== 'object' || !manifest.auth.type) {
+      errors.push('auth must be an object with a type field');
+    }
+  }
+  if (manifest.operations !== undefined) {
+    if (!Array.isArray(manifest.operations)) {
+      errors.push('operations must be an array');
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Build serviceInfo from a validated manifest
+ * @param {object} manifest - Validated manifest
+ * @returns {object} serviceInfo compatible with serviceRegistry
+ */
+function buildServiceInfo(manifest) {
+  const authMethods = [];
+  if (manifest.auth?.type) {
+    authMethods.push(manifest.auth.type);
+  }
+  return {
+    key: manifest.name,
+    name: manifest.displayName,
+    shortDesc: manifest.description || manifest.displayName,
+    description: manifest.description || `${manifest.displayName} plugin`,
+    authType: manifest.auth?.type || 'none',
+    authMethods,
+    authFields: manifest.auth?.fields || [],
+    baseUrl: manifest.baseUrl || '',
+    docs: manifest.docs || '',
+    examples: manifest.examples || [],
+    operations: manifest.operations || [],
+    isPlugin: true
+  };
+}
+
+/**
+ * Load all plugins from the plugins directory
+ * @returns {Promise<Map<string, object>>} Map of loaded plugins
+ */
+export async function loadPlugins() {
+  loadedPlugins.clear();
+  const pluginsDir = process.env.AGENTGATE_PLUGINS_DIR || DEFAULT_PLUGINS_DIR;
+
+  try {
+    await access(pluginsDir);
+  } catch {
+    console.log(`Plugins directory not found: ${pluginsDir} (skipping plugin loading)`);
+    return loadedPlugins;
+  }
+
+  let entries;
+  try {
+    entries = await readdir(pluginsDir, { withFileTypes: true });
+  } catch {
+    console.warn(`Cannot read plugins directory: ${pluginsDir}`);
+    return loadedPlugins;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const pluginDir = join(pluginsDir, entry.name);
+    const manifestPath = join(pluginDir, 'manifest.json');
+    const handlerPathMjs = join(pluginDir, 'handler.mjs');
+    const handlerPathJs = join(pluginDir, 'handler.js');
+
+    try {
+      // Read and validate manifest
+      const manifestRaw = await readFile(manifestPath, 'utf-8');
+      const manifest = JSON.parse(manifestRaw);
+      const { valid, errors } = validateManifest(manifest);
+      if (!valid) {
+        console.warn(`Plugin "${entry.name}" has invalid manifest: ${errors.join(', ')}`);
+        continue;
+      }
+
+      // Check handler exists (.mjs preferred, .js fallback)
+      let handlerPath;
+      try {
+        await access(handlerPathMjs);
+        handlerPath = handlerPathMjs;
+      } catch {
+        await access(handlerPathJs);
+        handlerPath = handlerPathJs;
+      }
+
+      // Dynamic import handler
+      const handler = await import(pathToFileURL(handlerPath).href);
+
+      const serviceInfo = handler.serviceInfo || buildServiceInfo(manifest);
+      const readService = handler.readService || null;
+      const router = handler.default || null;
+
+      loadedPlugins.set(manifest.name, {
+        manifest,
+        serviceInfo,
+        readService,
+        router,
+        pluginDir
+      });
+
+      console.log(`Loaded plugin: ${manifest.displayName} v${manifest.version}`);
+    } catch (err) {
+      console.warn(`Failed to load plugin "${entry.name}": ${err.message}`);
+    }
+  }
+
+  return loadedPlugins;
+}
+
+/**
+ * Get all loaded plugins
+ * @returns {Map<string, object>}
+ */
+export function getLoadedPlugins() {
+  return loadedPlugins;
+}
+
+/**
+ * Get a specific loaded plugin by name
+ * @param {string} name - Plugin name
+ * @returns {object|null}
+ */
+export function getPlugin(name) {
+  return loadedPlugins.get(name) || null;
+}

--- a/src/lib/pluginRouter.js
+++ b/src/lib/pluginRouter.js
@@ -1,0 +1,34 @@
+import { getLoadedPlugins } from './pluginLoader.js';
+import { apiKeyAuth, writeProxy, serviceAccessCheck } from './middleware.js';
+import { registerPlugin } from './serviceRegistry.js';
+
+/**
+ * Register all loaded plugin routes on the Express app
+ * @param {import('express').Application} app - Express app instance
+ */
+export function registerPluginRoutes(app) {
+  const plugins = getLoadedPlugins();
+
+  for (const [name, plugin] of plugins) {
+    // Register in service registry so MCP, skills, readme all pick it up
+    // This will throw if the name collides with a built-in service
+    try {
+      registerPlugin(name, plugin.serviceInfo, plugin.readService);
+    } catch (err) {
+      console.warn(`Skipping plugin "${name}": ${err.message}`);
+      continue;
+    }
+
+    // Mount Express router if plugin provides one
+    if (plugin.router) {
+      app.use(
+        `/api/${name}`,
+        apiKeyAuth,
+        serviceAccessCheck(name),
+        writeProxy(name),
+        plugin.router
+      );
+      console.log(`Registered plugin routes: /api/${name}`);
+    }
+  }
+}

--- a/src/lib/serviceRegistry.js
+++ b/src/lib/serviceRegistry.js
@@ -27,6 +27,27 @@ const SERVICE_REGISTRY = {
   [homeassistantInfo.key]: homeassistantInfo
 };
 
+// Reserved route prefixes that plugins must not shadow
+const RESERVED_PATHS = new Set([
+  'queue', 'agents', 'services', 'llm', 'skill',
+  'agent_start_here', 'readme'
+]);
+
+/**
+ * Check if a service key would collide with built-in services or reserved paths
+ * @param {string} key - Service key to check
+ * @returns {{ collision: boolean, reason: string }}
+ */
+export function checkNameCollision(key) {
+  if (SERVICE_REGISTRY[key]) {
+    return { collision: true, reason: `Collides with built-in service: ${key}` };
+  }
+  if (RESERVED_PATHS.has(key)) {
+    return { collision: true, reason: `Collides with reserved API path: /api/${key}` };
+  }
+  return { collision: false, reason: '' };
+}
+
 /**
  * Get service info by key
  * @param {string} key - Service key (e.g., 'github', 'bluesky')
@@ -59,7 +80,8 @@ export const SERVICE_CATEGORIES = {
   social:   { name: 'Social',   description: 'Social networks — posts, profiles, timelines', services: ['bluesky', 'mastodon', 'reddit', 'linkedin'], hasWrite: true },
   code:     { name: 'Code',     description: 'Code repos, issues, PRs, projects', services: ['github', 'jira'], hasWrite: true },
   personal: { name: 'Personal', description: 'Health, calendar, and media', services: ['fitbit', 'calendar', 'google_calendar', 'youtube'], hasWrite: true },
-  iot:      { name: 'IoT',      description: 'Smart home and IoT devices', services: ['homeassistant'], hasWrite: true }
+  iot:      { name: 'IoT',      description: 'Smart home and IoT devices', services: ['homeassistant'], hasWrite: true },
+  plugins:  { name: 'Plugins',  description: 'User-installed custom service plugins', services: [], hasWrite: true }
 };
 
 /**
@@ -72,6 +94,30 @@ export function getServiceCategory(serviceKey) {
     if (info.services.includes(serviceKey)) return cat;
   }
   return null;
+}
+
+/**
+ * Register a plugin service dynamically after initial load.
+ * Throws if the plugin name collides with a built-in service or reserved path.
+ * @param {string} key - Service key (plugin name)
+ * @param {object} info - serviceInfo object
+ * @param {Function|null} readFn - readService function for MCP
+ */
+export function registerPlugin(key, info, readFn) {
+  const { collision, reason } = checkNameCollision(key);
+  if (collision) {
+    throw new Error(`Plugin "${key}" cannot be registered: ${reason}`);
+  }
+
+  SERVICE_REGISTRY[key] = info;
+  if (readFn) {
+    SERVICE_READERS[key] = readFn;
+  }
+  // Add to plugins category
+  if (!SERVICE_CATEGORIES.plugins.services.includes(key)) {
+    SERVICE_CATEGORIES.plugins.services.push(key);
+  }
+  console.log(`Registered plugin service: ${key}`);
 }
 
 export default SERVICE_REGISTRY;

--- a/tests/pluginLoader.test.js
+++ b/tests/pluginLoader.test.js
@@ -1,0 +1,185 @@
+import { mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { validateManifest, loadPlugins, getPlugin } from '../src/lib/pluginLoader.js';
+import { registerPlugin, checkNameCollision } from '../src/lib/serviceRegistry.js';
+
+const TEST_DIR = join(tmpdir(), 'agentgate-plugin-test-' + Date.now());
+
+function validManifest(overrides = {}) {
+  return {
+    name: 'test-service',
+    displayName: 'Test Service',
+    version: '1.0.0',
+    description: 'A test plugin',
+    auth: { type: 'api_key', fields: [{ name: 'apiKey', label: 'API Key', type: 'password' }] },
+    baseUrl: 'https://api.example.com',
+    operations: [
+      { method: 'GET', pattern: '/*', description: 'Read' }
+    ],
+    ...overrides
+  };
+}
+
+describe('validateManifest', () => {
+  it('accepts a valid manifest', () => {
+    const { valid, errors } = validateManifest(validManifest());
+    expect(valid).toBe(true);
+    expect(errors.length).toBe(0);
+  });
+
+  it('rejects null manifest', () => {
+    const { valid } = validateManifest(null);
+    expect(valid).toBe(false);
+  });
+
+  it('rejects missing name', () => {
+    const { valid, errors } = validateManifest(validManifest({ name: '' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('name'))).toBe(true);
+  });
+
+  it('rejects missing displayName', () => {
+    const { valid, errors } = validateManifest(validManifest({ displayName: '' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('displayName'))).toBe(true);
+  });
+
+  it('rejects missing version', () => {
+    const { valid, errors } = validateManifest(validManifest({ version: '' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('version'))).toBe(true);
+  });
+
+  it('rejects invalid version format', () => {
+    const { valid, errors } = validateManifest(validManifest({ version: 'abc' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('semver'))).toBe(true);
+  });
+
+  it('rejects invalid name characters', () => {
+    const { valid, errors } = validateManifest(validManifest({ name: 'My Service!' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('lowercase'))).toBe(true);
+  });
+
+  it('rejects invalid auth shape', () => {
+    const { valid, errors } = validateManifest(validManifest({ auth: 'bad' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('auth'))).toBe(true);
+  });
+
+  it('rejects non-array operations', () => {
+    const { valid, errors } = validateManifest(validManifest({ operations: 'bad' }));
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('operations'))).toBe(true);
+  });
+});
+
+describe('checkNameCollision', () => {
+  it('detects collision with built-in service', () => {
+    const { collision, reason } = checkNameCollision('github');
+    expect(collision).toBe(true);
+    expect(reason).toMatch(/built-in service/);
+  });
+
+  it('detects collision with reserved path', () => {
+    const { collision, reason } = checkNameCollision('queue');
+    expect(collision).toBe(true);
+    expect(reason).toMatch(/reserved API path/);
+  });
+
+  it('detects collision with agents path', () => {
+    const { collision, reason } = checkNameCollision('agents');
+    expect(collision).toBe(true);
+    expect(reason).toMatch(/reserved API path/);
+  });
+
+  it('allows non-colliding name', () => {
+    const { collision } = checkNameCollision('my-custom-plugin');
+    expect(collision).toBe(false);
+  });
+});
+
+describe('registerPlugin', () => {
+  it('throws on built-in service collision', () => {
+    expect(() => {
+      registerPlugin('github', { key: 'github', name: 'Fake GitHub' }, null);
+    }).toThrow(/cannot be registered/);
+  });
+
+  it('throws on reserved path collision', () => {
+    expect(() => {
+      registerPlugin('queue', { key: 'queue', name: 'Fake Queue' }, null);
+    }).toThrow(/cannot be registered/);
+  });
+});
+
+describe('loadPlugins', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_DIR, { recursive: true });
+    process.env.AGENTGATE_PLUGINS_DIR = TEST_DIR;
+  });
+
+  afterEach(async () => {
+    delete process.env.AGENTGATE_PLUGINS_DIR;
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('returns empty map when plugins dir has no plugins', async () => {
+    const plugins = await loadPlugins();
+    expect(plugins instanceof Map).toBe(true);
+  });
+
+  it('loads a valid plugin', async () => {
+    const pluginDir = join(TEST_DIR, 'my-plugin');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, 'manifest.json'),
+      JSON.stringify(validManifest({ name: 'my-plugin', displayName: 'My Plugin' }))
+    );
+    // Minimal handler — use .mjs to ensure ESM parsing
+    await writeFile(join(pluginDir, 'handler.mjs'), [
+      'export const serviceInfo = { key: \'my-plugin\', name: \'My Plugin\' };',
+      'export default null;'
+    ].join('\n'));
+
+    const plugins = await loadPlugins();
+    expect(plugins.has('my-plugin')).toBe(true);
+    expect(plugins.get('my-plugin').serviceInfo.name).toBe('My Plugin');
+  });
+
+  it('skips plugin with invalid manifest', async () => {
+    const pluginDir = join(TEST_DIR, 'bad-plugin');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, 'manifest.json'), JSON.stringify({ name: '' }));
+    await writeFile(join(pluginDir, 'handler.js'), 'export default null;');
+
+    const plugins = await loadPlugins();
+    expect(plugins.has('bad-plugin')).toBe(false);
+  });
+
+  it('skips plugin with missing handler.js', async () => {
+    const pluginDir = join(TEST_DIR, 'no-handler');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, 'manifest.json'),
+      JSON.stringify(validManifest({ name: 'no-handler' }))
+    );
+
+    const plugins = await loadPlugins();
+    expect(plugins.has('no-handler')).toBe(false);
+  });
+
+  it('handles non-existent plugins directory gracefully', async () => {
+    process.env.AGENTGATE_PLUGINS_DIR = '/tmp/nonexistent-agentgate-plugins-xyz';
+    const plugins = await loadPlugins();
+    expect(plugins instanceof Map).toBe(true);
+  });
+});
+
+describe('getPlugin', () => {
+  it('returns null for unknown plugin', () => {
+    expect(getPlugin('nonexistent')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Custom Service Plugins Architecture

Closes #247

### What
A plugin system that lets users add custom services without modifying core code.

### How it works
1. Users create plugins in `~/.agentgate/plugins/{name}/` with `manifest.json` + `handler.js`
2. At startup, `pluginLoader.js` discovers and validates plugins
3. `pluginRouter.js` mounts Express routes with standard middleware (auth, read-only, access check)
4. `serviceRegistry.js` gains `registerPlugin()` so plugins appear in MCP, skills, and readme automatically

### New Files
- **`src/lib/pluginLoader.js`** — Plugin discovery, manifest validation, dynamic import
- **`src/lib/pluginRouter.js`** — Dynamic route registration on Express app
- **`tests/pluginLoader.test.js`** — Manifest validation and plugin discovery tests

### Modified Files
- **`src/lib/serviceRegistry.js`** — Added `registerPlugin()` and `plugins` category
- **`src/index.js`** — Load plugins before server listen, register plugin routes

### Design decisions
- Plugin dir: `~/.agentgate/plugins/` (configurable via `AGENTGATE_PLUGINS_DIR` env var)
- Auth: reuses existing credential store with plugin name as service key
- No sandboxing v1 — plugins run in same process
- No hot reload v1 — load at startup only
- Plugins inherit all existing infrastructure (MCP, skills, access control)

### Reviewer
@Luthien — mandatory review