### PR TITLE
fix: constrain logo size on login page

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -546,6 +546,34 @@ code {
   border: 1px solid var(--primary);
 }
 
+.auth-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.auth-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.auth-logo img {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+}
+
+.auth-logo h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
 .main-nav {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Bug

Logo is way too big on the login screen. The SVG favicon has no intrinsic width/height attributes, so it expands to fill its container.

## Fix

Add CSS styles for `.auth-container`, `.auth-logo`, and `.auth-logo img` in `style.css`:
- Logo constrained to 64x64px with border-radius
- Login form centered vertically and horizontally
- Also fixes the same issue on the setup-password page (same classes)

**Tests:** All 5 suites pass (70/70) ✅
**Lint:** Clean ✅