### PR TITLE
feat: add pagination to queue views (25 items per page)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -546,6 +546,34 @@ code {
   border: 1px solid var(--primary);
 }
 
+.auth-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.auth-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.auth-logo img {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+}
+
+.auth-logo h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
 .main-nav {
   display: flex;
   gap: 8px;
@@ -1559,6 +1587,10 @@ body > p:first-of-type {
     .btn-danger:hover {
       background: rgba(239, 68, 68, 0.2);
     }
+
+/* ===== Pagination ===== */
+.pagination { display: flex; align-items: center; justify-content: center; gap: 16px; margin-top: 24px; }
+.pagination .page-info { color: var(--text-muted); font-size: 14px; }
 
 /* ===== Messages Page ===== */
 .filter-bar { display: flex; gap: 10px; margin-bottom: 24px; flex-wrap: wrap; align-items: center; }

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -1012,12 +1012,20 @@ export function getQueueEntry(id) {
   };
 }
 
-export function listQueueEntries(status) {
+export function listQueueEntries(status, { limit, offset } = {}) {
   let rows;
   if (status) {
-    rows = db.prepare('SELECT * FROM write_queue WHERE status = ? ORDER BY submitted_at DESC').all(status);
+    if (limit !== null) {
+      rows = db.prepare('SELECT * FROM write_queue WHERE status = ? ORDER BY submitted_at DESC LIMIT ? OFFSET ?').all(status, limit, offset || 0);
+    } else {
+      rows = db.prepare('SELECT * FROM write_queue WHERE status = ? ORDER BY submitted_at DESC').all(status);
+    }
   } else {
-    rows = db.prepare('SELECT * FROM write_queue ORDER BY submitted_at DESC').all();
+    if (limit !== null) {
+      rows = db.prepare('SELECT * FROM write_queue ORDER BY submitted_at DESC LIMIT ? OFFSET ?').all(limit, offset || 0);
+    } else {
+      rows = db.prepare('SELECT * FROM write_queue ORDER BY submitted_at DESC').all();
+    }
   }
   return rows.map(row => ({
     ...row,
@@ -1028,8 +1036,13 @@ export function listQueueEntries(status) {
   }));
 }
 
-export function listAutoApprovedEntries() {
-  const rows = db.prepare('SELECT * FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC').all();
+export function listAutoApprovedEntries({ limit, offset } = {}) {
+  let rows;
+  if (limit !== null) {
+    rows = db.prepare('SELECT * FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC LIMIT ? OFFSET ?').all(limit, offset || 0);
+  } else {
+    rows = db.prepare('SELECT * FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC').all();
+  }
   return rows.map(row => ({
     ...row,
     requests: JSON.parse(row.requests),

--- a/src/routes/ui/queue.js
+++ b/src/routes/ui/queue.js
@@ -24,16 +24,26 @@ function validateReactionEmoji(emoji) {
 }
 
 // Write Queue Management
+const PAGE_SIZE = 25;
+
 router.get('/', (req, res) => {
   const filter = req.query.filter || 'pending';
+  const page = Math.max(1, parseInt(req.query.page) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
+  const pagination = { limit: PAGE_SIZE + 1, offset };
+
   let entries;
   if (filter === 'all') {
-    entries = listQueueEntries();
+    entries = listQueueEntries(undefined, pagination);
   } else if (filter === 'auto-approved') {
-    entries = listAutoApprovedEntries();
+    entries = listAutoApprovedEntries(pagination);
   } else {
-    entries = listQueueEntries(filter);
+    entries = listQueueEntries(filter, pagination);
   }
+
+  const hasNext = entries.length > PAGE_SIZE;
+  if (hasNext) entries = entries.slice(0, PAGE_SIZE);
+
   const counts = getQueueCounts();
   counts['auto-approved'] = getAutoApprovedCount();
   renderPage(res, 'pages/queue', {
@@ -42,6 +52,8 @@ router.get('/', (req, res) => {
     entries,
     filter,
     counts,
+    page,
+    hasNext,
     allEmojis: ALL_EMOJIS,
     escapeHtml,
     renderMarkdownLinks,

--- a/views/pages/queue.ejs
+++ b/views/pages/queue.ejs
@@ -151,6 +151,17 @@
       </div>
     </div>
   <% }); %>
+
+  <div class="pagination">
+    <% if (page > 1) { %>
+      <a href="/ui/queue?filter=<%= filter %>&page=<%= page - 1 %>" class="btn-sm">&laquo; Previous</a>
+    <% } %>
+    <span class="page-info">Page <%= page %></span>
+    <% if (hasNext) { %>
+      <a href="/ui/queue?filter=<%= filter %>&page=<%= page + 1 %>" class="btn-sm">Next &raquo;</a>
+    <% } %>
+  </div>
+
 <% } %>
 </div>
 


### PR DESCRIPTION
## Feature

Add pagination to all queue views in the admin UI, 25 items per page.

## Changes

- **src/lib/db.js**: Add optional `{ limit, offset }` params to `listQueueEntries()` and `listAutoApprovedEntries()`
- **src/routes/ui/queue.js**: Parse `page` query param, fetch `PAGE_SIZE + 1` items to detect if there's a next page, pass `page`/`hasNext` to view
- **views/pages/queue.ejs**: Add Previous/Next pagination controls below entries
- **public/style.css**: Add `.pagination` styles

All filters (pending, completed, failed, rejected, withdrawn, auto-approved, all) are paginated.

**Tests:** All 5 suites pass (70/70) ✅
**Lint:** Clean ✅