### PR TITLE
feat: lazy-load queue entry details via AJAX

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -1012,44 +1012,73 @@ export function getQueueEntry(id) {
   };
 }
 
-export function listQueueEntries(status, { limit, offset } = {}) {
-  let rows;
-  if (status) {
-    if (limit !== null) {
-      rows = db.prepare('SELECT * FROM write_queue WHERE status = ? ORDER BY submitted_at DESC LIMIT ? OFFSET ?').all(status, limit, offset || 0);
-    } else {
-      rows = db.prepare('SELECT * FROM write_queue WHERE status = ? ORDER BY submitted_at DESC').all(status);
-    }
-  } else {
-    if (limit !== null) {
-      rows = db.prepare('SELECT * FROM write_queue ORDER BY submitted_at DESC LIMIT ? OFFSET ?').all(limit, offset || 0);
-    } else {
-      rows = db.prepare('SELECT * FROM write_queue ORDER BY submitted_at DESC').all();
-    }
-  }
-  return rows.map(row => ({
+const QUEUE_LIGHT_COLS = 'id, service, account_name, comment, status, rejection_reason, submitted_by, submitted_at, reviewed_at, completed_at, notified, notified_at, notify_error, auto_approved, reaction_emoji, requests';
+
+function mapQueueRow(row) {
+  return {
     ...row,
     requests: JSON.parse(row.requests),
     results: row.results ? JSON.parse(row.results) : null,
     notified: Boolean(row.notified),
     auto_approved: Boolean(row.auto_approved)
-  }));
+  };
 }
 
-export function listAutoApprovedEntries({ limit, offset } = {}) {
-  let rows;
-  if (limit !== null) {
-    rows = db.prepare('SELECT * FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC LIMIT ? OFFSET ?').all(limit, offset || 0);
-  } else {
-    rows = db.prepare('SELECT * FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC').all();
-  }
-  return rows.map(row => ({
-    ...row,
-    requests: JSON.parse(row.requests),
-    results: row.results ? JSON.parse(row.results) : null,
+function mapQueueRowLight(row) {
+  const requests = JSON.parse(row.requests);
+  return {
+    id: row.id,
+    service: row.service,
+    account_name: row.account_name,
+    comment: row.comment,
+    status: row.status,
+    rejection_reason: row.rejection_reason,
+    submitted_by: row.submitted_by,
+    submitted_at: row.submitted_at,
+    reviewed_at: row.reviewed_at,
+    completed_at: row.completed_at,
     notified: Boolean(row.notified),
-    auto_approved: true
-  }));
+    notified_at: row.notified_at,
+    notify_error: row.notify_error,
+    auto_approved: Boolean(row.auto_approved),
+    reaction_emoji: row.reaction_emoji,
+    requestSummary: requests.map(r => ({ method: r.method, path: r.path })),
+    resultCount: row.result_count || 0
+  };
+}
+
+export function listQueueEntries(status, { limit, offset, light } = {}) {
+  const cols = light
+    ? QUEUE_LIGHT_COLS + ', (CASE WHEN results IS NOT NULL THEN json_array_length(results) ELSE 0 END) as result_count'
+    : '*';
+  let rows;
+  if (status) {
+    if (limit !== null && limit !== undefined) {
+      rows = db.prepare(`SELECT ${cols} FROM write_queue WHERE status = ? ORDER BY submitted_at DESC LIMIT ? OFFSET ?`).all(status, limit, offset || 0);
+    } else {
+      rows = db.prepare(`SELECT ${cols} FROM write_queue WHERE status = ? ORDER BY submitted_at DESC`).all(status);
+    }
+  } else {
+    if (limit !== null && limit !== undefined) {
+      rows = db.prepare(`SELECT ${cols} FROM write_queue ORDER BY submitted_at DESC LIMIT ? OFFSET ?`).all(limit, offset || 0);
+    } else {
+      rows = db.prepare(`SELECT ${cols} FROM write_queue ORDER BY submitted_at DESC`).all();
+    }
+  }
+  return rows.map(light ? mapQueueRowLight : mapQueueRow);
+}
+
+export function listAutoApprovedEntries({ limit, offset, light } = {}) {
+  const cols = light
+    ? QUEUE_LIGHT_COLS + ', (CASE WHEN results IS NOT NULL THEN json_array_length(results) ELSE 0 END) as result_count'
+    : '*';
+  let rows;
+  if (limit !== null && limit !== undefined) {
+    rows = db.prepare(`SELECT ${cols} FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC LIMIT ? OFFSET ?`).all(limit, offset || 0);
+  } else {
+    rows = db.prepare(`SELECT ${cols} FROM write_queue WHERE auto_approved = 1 ORDER BY submitted_at DESC`).all();
+  }
+  return rows.map(light ? mapQueueRowLight : mapQueueRow);
 }
 
 export function getAutoApprovedCount() {

--- a/src/routes/ui/queue.js
+++ b/src/routes/ui/queue.js
@@ -31,7 +31,7 @@ router.get('/', (req, res) => {
   const filter = req.query.filter || 'pending';
   const page = Math.max(1, parseInt(req.query.page) || 1);
   const offset = (page - 1) * PAGE_SIZE;
-  const pagination = { limit: PAGE_SIZE + 1, offset };
+  const pagination = { limit: PAGE_SIZE + 1, offset, light: true };
 
   let entries;
   if (filter === 'all') {
@@ -63,6 +63,16 @@ router.get('/', (req, res) => {
     formatDate,
     renderAvatar,
     getQueueWarnings
+  });
+});
+
+// Lazy-load full details for a queue entry
+router.get('/:id/details', (req, res) => {
+  const entry = getQueueEntry(req.params.id);
+  if (!entry) return res.status(404).json({ error: 'Not found' });
+  res.json({
+    requests: entry.requests,
+    results: entry.results
   });
 });
 

--- a/views/pages/queue.ejs
+++ b/views/pages/queue.ejs
@@ -35,7 +35,7 @@
 <% } else { %>
   <% entries.forEach(function(entry) { %>
     <%
-      var requestsSummary = entry.requests.map(function(r) {
+      var requestsSummary = entry.requestSummary.map(function(r) {
         return '<div class="request-item"><code>' + r.method + '</code> <span>' + escapeHtml(r.path) + '</span></div>';
       }).join('');
 
@@ -68,15 +68,15 @@
         <%- requestsSummary %>
       </div>
 
-      <details class="mt-12">
-        <summary>Request Details</summary>
-        <pre class="meta-line"><%- escapeHtml(JSON.stringify(entry.requests, null, 2)) %></pre>
+      <details class="mt-12 lazy-details" data-entry-id="<%= entry.id %>" data-field="requests">
+        <summary>Request Details (<%= entry.requestSummary.length %>)</summary>
+        <div class="lazy-content"><span class="loading-text">Loading...</span></div>
       </details>
 
-      <% if (entry.results) { %>
-        <details class="mt-12">
-          <summary>Results (<%= entry.results.length %>)</summary>
-          <pre class="meta-line"><%- escapeHtml(JSON.stringify(entry.results, null, 2)) %></pre>
+      <% if (entry.resultCount > 0) { %>
+        <details class="mt-12 lazy-details" data-entry-id="<%= entry.id %>" data-field="results">
+          <summary>Results (<%= entry.resultCount %>)</summary>
+          <div class="lazy-content"><span class="loading-text">Loading...</span></div>
         </details>
       <% } %>
 
@@ -169,6 +169,32 @@
 </div>
 
 <script>
+  // Lazy-load details on expand
+  const detailsCache = {};
+  document.addEventListener('toggle', async function(e) {
+    const details = e.target.closest('.lazy-details');
+    if (!details || !details.open) return;
+    const entryId = details.dataset.entryId;
+    const field = details.dataset.field;
+    const container = details.querySelector('.lazy-content');
+    if (container.dataset.loaded) return;
+
+    try {
+      if (!detailsCache[entryId]) {
+        const res = await fetch('/ui/queue/' + entryId + '/details', {
+          headers: { 'Accept': 'application/json' }
+        });
+        if (!res.ok) throw new Error('Failed to load');
+        detailsCache[entryId] = await res.json();
+      }
+      const data = detailsCache[entryId][field];
+      container.innerHTML = '<pre class="meta-line">' + escapeHtml(JSON.stringify(data, null, 2)) + '</pre>';
+      container.dataset.loaded = '1';
+    } catch (err) {
+      container.innerHTML = '<p class="error">Failed to load details</p>';
+    }
+  }, true);
+
   function escapeHtml(str) {
     if (typeof str !== 'string') str = JSON.stringify(str, null, 2);
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');


### PR DESCRIPTION
## Problem

Queue list page loads all request details + results JSON for every entry on page load — too heavy when there are many entries.

## Solution

Initial render now sends only lightweight summaries (method + path per request, result count). Full details are lazy-loaded via AJAX when the user expands a details section.

### Changes

- **src/routes/ui/queue.js**:
  - Strip `requests`/`results` from initial page data, send `requestSummary` and `resultCount` instead
  - Add `GET /:id/details` JSON endpoint returning full requests + results
- **views/pages/queue.ejs**:
  - Use `requestSummary` for the summary row
  - Replace inline `<details>` with lazy-loading: fetches from `/ui/queue/:id/details` on expand
  - Client-side cache so repeated expand/collapse doesn't re-fetch

**Tests:** All 5 suites pass (70/70) ✅
**Lint:** Clean ✅