### PR TITLE
feat: add pagination to messages view (25 per page)

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -1293,9 +1293,16 @@ export function rejectAgentMessage(id, reason) {
 }
 
 // Admin: list all messages (for UI)
-export function listAgentMessages(status = null) {
+export function listAgentMessages(status = null, { limit, offset } = {}) {
+  const hasLimit = limit !== null && limit !== undefined;
   if (status) {
+    if (hasLimit) {
+      return db.prepare('SELECT * FROM agent_messages WHERE status = ? ORDER BY created_at DESC LIMIT ? OFFSET ?').all(status, limit, offset || 0);
+    }
     return db.prepare('SELECT * FROM agent_messages WHERE status = ? ORDER BY created_at DESC').all(status);
+  }
+  if (hasLimit) {
+    return db.prepare('SELECT * FROM agent_messages ORDER BY created_at DESC LIMIT ? OFFSET ?').all(limit, offset || 0);
   }
   return db.prepare('SELECT * FROM agent_messages ORDER BY created_at DESC').all();
 }

--- a/src/routes/ui/messages.js
+++ b/src/routes/ui/messages.js
@@ -13,19 +13,28 @@ import { escapeHtml, statusBadge, formatDate, renderAvatar } from './shared.js';
 import { renderPage } from '../../lib/render.js';
 
 const router = Router();
+const PAGE_SIZE = 25;
 
 // Agent Messages Queue
 router.get('/', (req, res) => {
   const filter = req.query.filter || 'all';
+  const page = Math.max(1, parseInt(req.query.page) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
+  const pagination = { limit: PAGE_SIZE + 1, offset };
+
   let messages;
   if (filter === 'all') {
-    messages = listAgentMessages();
+    messages = listAgentMessages(null, pagination);
   } else {
-    messages = listAgentMessages(filter);
+    messages = listAgentMessages(filter, pagination);
   }
+
+  const hasNext = messages.length > PAGE_SIZE;
+  if (hasNext) messages = messages.slice(0, PAGE_SIZE);
+
   const counts = getMessageCounts();
   const mode = getMessagingMode();
-  const broadcasts = listBroadcastsWithRecipients(10);
+  const broadcasts = page === 1 ? listBroadcastsWithRecipients(10) : [];
 
   // Build timeline
   const messageItems = messages.map(m => ({ ...m, _type: 'message' }));
@@ -42,6 +51,8 @@ router.get('/', (req, res) => {
     mode,
     broadcasts,
     timeline,
+    page,
+    hasNext,
     renderAvatar,
     escapeHtml,
     formatDate,

--- a/views/pages/messages.ejs
+++ b/views/pages/messages.ejs
@@ -55,6 +55,17 @@
         <%- include('../partials/message-entry', { msg: item, renderAvatar, escapeHtml, formatDate, statusBadge }) %>
       <% } %>
     <% }); %>
+
+    <div class="pagination">
+      <% if (page > 1) { %>
+        <a href="/ui/messages?filter=<%= filter %>&page=<%= page - 1 %>" class="btn-sm">&laquo; Previous</a>
+      <% } %>
+      <span class="page-info">Page <%= page %></span>
+      <% if (hasNext) { %>
+        <a href="/ui/messages?filter=<%= filter %>&page=<%= page + 1 %>" class="btn-sm">Next &raquo;</a>
+      <% } %>
+    </div>
+
   <% } %>
 </div>
 


### PR DESCRIPTION
## Feature

Add pagination to the messages view, 25 items per page. Same pattern as queue pagination (#300).

## Changes

- **src/lib/db.js**: Add `{ limit, offset }` params to `listAgentMessages()`
- **src/routes/ui/messages.js**: Parse `page` query param, fetch PAGE_SIZE+1 to detect next page, pass `page`/`hasNext` to view. Broadcasts only loaded on page 1.
- **views/pages/messages.ejs**: Add Previous/Next pagination controls (reuses `.pagination` CSS)

**Tests:** All 6 suites pass (82/82) ✅
**Lint:** Clean ✅

Closes #303