### PR TITLE
fix: normalize UTC timestamps for correct time display

### DIFF
--- a/src/routes/ui/shared.js
+++ b/src/routes/ui/shared.js
@@ -84,7 +84,8 @@ export function localizeScript() {
       document.querySelectorAll('.local-time[data-utc]').forEach(function(el) {
         const utc = el.getAttribute('data-utc');
         if (utc) {
-          const d = new Date(utc);
+          const normalized = utc.endsWith('Z') || utc.includes('+') ? utc : utc + 'Z';
+          const d = new Date(normalized);
           el.textContent = d.toLocaleString();
           el.title = utc + ' UTC';
         }


### PR DESCRIPTION
## Bug

Times displayed in the admin UI are wrong — they show UTC time as if it were local time.

## Cause

SQLite `CURRENT_TIMESTAMP` stores dates like `2026-02-18 17:08:00` (no timezone suffix). When JavaScript parses this with `new Date()`, it treats it as **local time** instead of UTC, causing times to display incorrectly.

## Fix

In the client-side localization script (`shared.js`), append `Z` to timestamps that don't already have a timezone indicator. This ensures `new Date()` correctly interprets them as UTC before converting to local time.

**Tests:** All 6 suites pass (82/82) ✅
**Lint:** Clean ✅