### PR TITLE
feat: add bio to /api/agents/messageable (#309)

### DIFF
--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -198,6 +198,7 @@ router.get('/messageable', async (req, res) => {
     .filter(k => k.name.toLowerCase() !== callerName.toLowerCase())
     .map(k => ({
       name: k.name,
+      bio: k.bio || '',
       enabled: !!k.enabled
     }));
 


### PR DESCRIPTION
Extends `/api/agents/messageable` to include agent bios per Luthien suggestion on #309.

Minimal one-line change — adds `bio` field (defaults to empty string) to existing response.

Closes #309

**Tests:** 6 suites, 82 passed, lint clean