### PR TITLE
feat: add bio to /api/agents/status (#313)

### DIFF
--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -169,12 +169,14 @@ router.get('/status', async (req, res) => {
   }
 
   const messages = getMessagesForAgent(agentName, true);
+  const agent = getApiKeyByName(agentName);
 
   return res.json({
     via: 'agentgate',
     mode,
     enabled: true,
-    unread_count: messages.length
+    unread_count: messages.length,
+    bio: (agent && agent.bio) || ''
   });
 });
 


### PR DESCRIPTION
Adds `bio` field to `/api/agents/status` so agents can read their own bio.

Same pattern as #312 for `/messageable`.

Closes #313

**Tests:** 6 suites, 82 passed, lint clean