### PR TITLE
docs: add table of contents (#316)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# agentgate Documentation
+
+## Getting Started
+
+- [Self-Hosting](self-hosting.md) — Set up and run your own agentgate instance
+- [Agent Setup](agent-setup.md) — Configure your AI agent to use agentgate
+
+## Core Features
+
+- [Write Queue](write-queue.md) — Human-approved write operations for external APIs
+- [Access Control](access-control.md) — Control which agents can access specific services
+- [Skills](skills.md) — Integrate with OpenClaw and ClawdBot agent skills
+
+## Agent Communication
+
+- [Inter-Agent Messaging](inter-agent-messaging.md) — Agent-to-agent coordination with human oversight
+- [Webhooks](webhooks.md) — Event notifications for agents
+
+## Advanced
+
+- [MCP Server](mcp.md) — Model Context Protocol server for AI assistants
+- [Mementos](memento.md) — Durable keyword-tagged memory storage for agents


### PR DESCRIPTION
Adds `docs/index.md` with categorized TOC:

- **Getting Started**: self-hosting, agent-setup
- **Core Features**: write-queue, access-control, skills
- **Agent Communication**: inter-agent-messaging, webhooks
- **Advanced**: mcp, memento

Note: `messaging.md` omitted as it overlaps with `inter-agent-messaging.md`.

Closes #316