### PR TITLE
feat: add Twilio SMS service (#320)

### DIFF
--- a/public/icons/twilio.svg
+++ b/public/icons/twilio.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#F22F46"/>
+  <circle cx="50" cy="50" r="35" fill="none" stroke="white" stroke-width="5"/>
+  <circle cx="38" cy="38" r="7" fill="white"/>
+  <circle cx="62" cy="38" r="7" fill="white"/>
+  <circle cx="38" cy="62" r="7" fill="white"/>
+  <circle cx="62" cy="62" r="7" fill="white"/>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import fitbitRoutes from './routes/fitbit.js';
 import braveRoutes from './routes/brave.js';
 import googleSearchRoutes from './routes/google-search.js';
 import homeassistantRoutes from './routes/homeassistant.js';
+import twilioRoutes from './routes/twilio.js';
 import queueRoutes from './routes/queue.js';
 import agentsRoutes from './routes/agents.js';
 import mementoRoutes from './routes/memento.js';
@@ -80,6 +81,7 @@ app.use('/api/fitbit', apiKeyAuth, serviceAccessCheck('fitbit'), writeProxy('fit
 app.use('/api/brave', apiKeyAuth, serviceAccessCheck('brave'), writeProxy('brave'), braveRoutes);
 app.use('/api/google_search', apiKeyAuth, serviceAccessCheck('google_search'), writeProxy('google_search'), googleSearchRoutes);
 app.use('/api/homeassistant', apiKeyAuth, serviceAccessCheck('homeassistant'), writeProxy('homeassistant'), homeassistantRoutes);
+app.use('/api/twilio', apiKeyAuth, serviceAccessCheck('twilio'), writeProxy('twilio'), twilioRoutes);
 
 // Service access management - admin API (requires auth)
 app.use('/api/services', apiKeyAuth, servicesRoutes);

--- a/src/lib/queueExecutor.js
+++ b/src/lib/queueExecutor.js
@@ -14,7 +14,8 @@ const SERVICE_URLS = {
   linkedin: 'https://api.linkedin.com/v2',
   jira: null, // Dynamic: https://{domain}/rest/api/3
   fitbit: 'https://api.fitbit.com',
-  homeassistant: null // Dynamic: {host}/api
+  homeassistant: null, // Dynamic: {host}/api
+  twilio: 'https://api.twilio.com/2010-04-01'
 };
 
 // Get access token for a service, refreshing if needed
@@ -54,6 +55,9 @@ export async function getAccessToken(service, accountName) {
 
   case 'homeassistant':
     return creds.token || null;
+
+  case 'twilio':
+    return creds;
 
   default:
     return null;
@@ -245,6 +249,9 @@ export function buildUrl(service, accountName, path) {
     const host = creds.host.replace(/\/+$/, '');
     return `${host}/api/${path.replace(/^\//, '')}`;
   }
+  if (service === 'twilio' && creds?.accountSid) {
+    return `https://api.twilio.com/2010-04-01/Accounts/${creds.accountSid}/${path.replace(/^\//, '')}`;
+  }
 
   const baseUrl = SERVICE_URLS[service];
   if (!baseUrl) return null;
@@ -262,6 +269,9 @@ export function buildHeaders(service, token, customHeaders = {}) {
 
   if (service === 'jira' && token?.email && token?.apiToken) {
     const basicAuth = Buffer.from(`${token.email}:${token.apiToken}`).toString('base64');
+    defaults['Authorization'] = `Basic ${basicAuth}`;
+  } else if (service === 'twilio' && token?.accountSid && token?.authToken) {
+    const basicAuth = Buffer.from(`${token.accountSid}:${token.authToken}`).toString('base64');
     defaults['Authorization'] = `Basic ${basicAuth}`;
   } else if (token && typeof token === 'string') {
     defaults['Authorization'] = `Bearer ${token}`;

--- a/src/lib/serviceRegistry.js
+++ b/src/lib/serviceRegistry.js
@@ -10,6 +10,7 @@ import { serviceInfo as fitbitInfo, readService as fitbitRead } from '../routes/
 import { serviceInfo as braveInfo, readService as braveRead } from '../routes/brave.js';
 import { serviceInfo as googleSearchInfo, readService as googleSearchRead } from '../routes/google-search.js';
 import { serviceInfo as homeassistantInfo, readService as homeassistantRead } from '../routes/homeassistant.js';
+import { serviceInfo as twilioInfo, readService as twilioRead } from '../routes/twilio.js';
 
 // Aggregate service metadata from all routes
 const SERVICE_REGISTRY = {
@@ -24,7 +25,8 @@ const SERVICE_REGISTRY = {
   [fitbitInfo.key]: fitbitInfo,
   [braveInfo.key]: braveInfo,
   [googleSearchInfo.key]: googleSearchInfo,
-  [homeassistantInfo.key]: homeassistantInfo
+  [homeassistantInfo.key]: homeassistantInfo,
+  [twilioInfo.key]: twilioInfo
 };
 
 /**
@@ -50,7 +52,8 @@ export const SERVICE_READERS = {
   [fitbitInfo.key]: fitbitRead,
   [braveInfo.key]: braveRead,
   [googleSearchInfo.key]: googleSearchRead,
-  [homeassistantInfo.key]: homeassistantRead
+  [homeassistantInfo.key]: homeassistantRead,
+  [twilioInfo.key]: twilioRead
 };
 
 // Category mapping for MCP tool registration
@@ -59,7 +62,8 @@ export const SERVICE_CATEGORIES = {
   social:   { name: 'Social',   description: 'Social networks — posts, profiles, timelines', services: ['bluesky', 'mastodon', 'reddit', 'linkedin'], hasWrite: true },
   code:     { name: 'Code',     description: 'Code repos, issues, PRs, projects', services: ['github', 'jira'], hasWrite: true },
   personal: { name: 'Personal', description: 'Health, calendar, and media', services: ['fitbit', 'calendar', 'google_calendar', 'youtube'], hasWrite: true },
-  iot:      { name: 'IoT',      description: 'Smart home and IoT devices', services: ['homeassistant'], hasWrite: true }
+  iot:      { name: 'IoT',      description: 'Smart home and IoT devices', services: ['homeassistant'], hasWrite: true },
+  messaging: { name: 'Messaging', description: 'SMS and messaging services', services: ['twilio'], hasWrite: true }
 };
 
 /**

--- a/src/routes/twilio.js
+++ b/src/routes/twilio.js
@@ -1,0 +1,102 @@
+import { Router } from 'express';
+import { getAccountCredentials } from '../lib/db.js';
+
+const router = Router();
+
+const TWILIO_BASE = 'https://api.twilio.com/2010-04-01';
+
+// Service metadata
+export const serviceInfo = {
+  key: 'twilio',
+  name: 'Twilio',
+  shortDesc: 'SMS messaging via Twilio',
+  description: 'Twilio API proxy for sending and managing SMS messages',
+  authType: 'basic',
+  authMethods: ['basic'],
+  docs: 'https://www.twilio.com/docs/sms/api',
+  examples: [
+    'GET /api/twilio/{accountName}/Messages.json',
+    'GET /api/twilio/{accountName}/Messages/{MessageSid}.json'
+  ],
+  writeGuidelines: [
+    'SMS messages cost money — confirm with user before sending',
+    'Always verify the recipient phone number before sending',
+    'Include country code in phone numbers (e.g., +1 for US)',
+    'Be mindful of SMS rate limits and carrier filtering'
+  ]
+};
+
+// Core read function
+export async function readService(accountName, path, { query = {} } = {}) {
+  const creds = getAccountCredentials('twilio', accountName);
+  if (!creds?.accountSid || !creds?.authToken) {
+    return {
+      status: 401,
+      data: {
+        error: 'Twilio credentials not configured',
+        hint: `Configure accountSid and authToken for account "${accountName}" in the AgentGate UI`
+      }
+    };
+  }
+
+  const basicAuth = Buffer.from(`${creds.accountSid}:${creds.authToken}`).toString('base64');
+  const queryString = new URLSearchParams(query).toString();
+  const url = `${TWILIO_BASE}/Accounts/${creds.accountSid}/${path.replace(/^\//, '')}${queryString ? '?' + queryString : ''}`;
+
+  const response = await fetch(url, {
+    headers: {
+      'Authorization': `Basic ${basicAuth}`,
+      'Accept': 'application/json'
+    }
+  });
+
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// GET messages list
+router.get('/:accountName/Messages.json', async (req, res) => {
+  try {
+    const result = await readService(req.params.accountName, 'Messages.json', { query: req.query });
+    res.status(result.status).json(result.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Twilio API request failed', message: error.message });
+  }
+});
+
+// GET single message
+router.get('/:accountName/Messages/:sid.json', async (req, res) => {
+  try {
+    const result = await readService(req.params.accountName, `Messages/${req.params.sid}.json`);
+    res.status(result.status).json(result.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Twilio API request failed', message: error.message });
+  }
+});
+
+// Account info
+router.get('/:accountName', async (req, res) => {
+  res.json({
+    service: 'twilio',
+    account: req.params.accountName,
+    description: 'Twilio SMS API proxy. List and read messages; send via write queue.',
+    examples: [
+      `GET /api/twilio/${req.params.accountName}/Messages.json`,
+      `GET /api/twilio/${req.params.accountName}/Messages/{MessageSid}.json`
+    ],
+    docs: 'https://www.twilio.com/docs/sms/api'
+  });
+});
+
+// Wildcard GET
+router.get('/:accountName/*', async (req, res) => {
+  try {
+    const path = req.params[0];
+    const result = await readService(req.params.accountName, path, { query: req.query });
+    res.status(result.status).json(result.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Twilio API request failed', message: error.message });
+  }
+});
+
+export default router;

--- a/src/routes/ui/service-detail.js
+++ b/src/routes/ui/service-detail.js
@@ -187,7 +187,8 @@ function getServiceIcon(service) {
     jira: '/public/icons/jira.svg',
     fitbit: '/public/icons/fitbit.svg',
     brave: '/public/icons/brave.svg',
-    google_search: '/public/icons/google-search.svg'
+    google_search: '/public/icons/google-search.svg',
+    twilio: '/public/icons/twilio.svg'
   };
   return icons[service] || '/public/favicon.svg';
 }
@@ -339,6 +340,21 @@ function getServiceFormFields(serviceName) {
           <button type="button" onclick="const i=document.getElementById('ha-token');const t=i.type==='password'?'text':'password';i.type=t;this.textContent=t==='password'?'Show':'Hide';" style="position:absolute;right:8px;top:50%;transform:translateY(-50%);border:none;background:none;cursor:pointer;color:var(--text-muted);font-size:0.85em;">Hide</button>
         </div>
         <p class="help">Create a token in Home Assistant: Profile → Security → Long-Lived Access Tokens → Create Token</p>
+      </div>`,
+
+    twilio: `
+      <div class="form-group">
+        <label>Account SID</label>
+        <input type="text" name="accountSid" placeholder="AC..." required autocomplete="off">
+        <p class="help">Find your Account SID in the <a href="https://console.twilio.com/" target="_blank">Twilio Console</a></p>
+      </div>
+      <div class="form-group">
+        <label>Auth Token</label>
+        <div style="position:relative;">
+          <input type="text" name="authToken" id="twilio-token" placeholder="Your auth token" required autocomplete="off" style="padding-right:60px;">
+          <button type="button" onclick="const i=document.getElementById('twilio-token');const t=i.type==='password'?'text':'password';i.type=t;this.textContent=t==='password'?'Show':'Hide';" style="position:absolute;right:8px;top:50%;transform:translateY(-50%);border:none;background:none;cursor:pointer;color:var(--text-muted);font-size:0.85em;">Hide</button>
+        </div>
+        <p class="help">Find your Auth Token in the Twilio Console dashboard</p>
       </div>`
   };
 

--- a/src/routes/ui/services.js
+++ b/src/routes/ui/services.js
@@ -22,6 +22,7 @@ import * as fitbit from './fitbit.js';
 import * as brave from './brave.js';
 import * as googleSearch from './google-search.js';
 import * as homeassistant from './homeassistant.js';
+import * as twilio from './twilio.js';
 
 // Export all implemented services in display order
 export const services = [
@@ -36,7 +37,8 @@ export const services = [
   linkedin,
   brave,
   googleSearch,
-  homeassistant
+  homeassistant,
+  twilio
 ];
 
 // Full service catalog with categories — includes both implemented and coming-soon services
@@ -82,6 +84,12 @@ export const catalog = [
     category: 'IoT & Smart Home',
     services: [
       { id: 'homeassistant', name: 'Home Assistant', icon: '🏠', implemented: true }
+    ]
+  },
+  {
+    category: 'Messaging',
+    services: [
+      { id: 'twilio', name: 'Twilio', icon: '📱', implemented: true }
     ]
   }
 ];
@@ -207,7 +215,8 @@ function getServiceIcon(service) {
     fitbit: '/public/icons/fitbit.svg',
     brave: '/public/icons/brave.svg',
     google_search: '/public/icons/google-search.svg',
-    homeassistant: '/public/icons/homeassistant.svg'
+    homeassistant: '/public/icons/homeassistant.svg',
+    twilio: '/public/icons/twilio.svg'
   };
   return icons[service] || '/public/favicon.svg';
 }

--- a/src/routes/ui/twilio.js
+++ b/src/routes/ui/twilio.js
@@ -1,0 +1,66 @@
+import { setAccountCredentials, deleteAccount } from '../../lib/db.js';
+import { escapeHtml } from './shared.js';
+
+export function registerRoutes(router) {
+  router.post('/twilio/setup', (req, res) => {
+    const { accountName, accountSid, authToken } = req.body;
+    if (!accountName || !accountSid || !authToken) {
+      return res.status(400).send('Account name, Account SID, and Auth Token required');
+    }
+    setAccountCredentials('twilio', accountName, { accountSid, authToken });
+    res.redirect('/ui');
+  });
+
+  router.post('/twilio/delete', (req, res) => {
+    const { accountName } = req.body;
+    deleteAccount('twilio', accountName);
+    res.redirect('/ui');
+  });
+}
+
+export function renderCard(accounts, _baseUrl) {
+  const serviceAccounts = accounts.filter(a => a.service === 'twilio');
+
+  const renderAccounts = () => {
+    if (serviceAccounts.length === 0) return '';
+    return serviceAccounts.map(acc => `
+      <div class="account-item">
+        <span><strong>${escapeHtml(acc.name)}</strong></span>
+        <form method="POST" action="/ui/twilio/delete" style="margin:0;">
+          <input type="hidden" name="accountName" value="${escapeHtml(acc.name)}" autocomplete="off">
+          <button type="submit" class="btn-sm btn-danger">Remove</button>
+        </form>
+      </div>
+    `).join('');
+  };
+
+  return `
+  <div class="card">
+    <div class="service-header">
+      <span class="service-icon" style="font-size:2em;">📱</span>
+      <h3>Twilio</h3>
+    </div>
+    ${renderAccounts()}
+    <details>
+      <summary>Add Twilio Account</summary>
+      <div style="margin-top: 15px;">
+        <p class="help">Find your Account SID and Auth Token in the <a href="https://console.twilio.com/" target="_blank">Twilio Console</a></p>
+        <form method="POST" action="/ui/twilio/setup">
+          <label>Account Name</label>
+          <input type="text" name="accountName" placeholder="main, production, etc." required autocomplete="off">
+          <label>Account SID</label>
+          <input type="text" name="accountSid" placeholder="AC..." required autocomplete="off">
+          <label>Auth Token</label>
+          <div style="position:relative;">
+            <input type="text" name="authToken" id="twilio-token-card" placeholder="Your auth token" required autocomplete="off" style="padding-right:60px;">
+            <button type="button" onclick="const i=document.getElementById('twilio-token-card');const t=i.type==='password'?'text':'password';i.type=t;this.textContent=t==='password'?'Show':'Hide';" style="position:absolute;right:8px;top:50%;transform:translateY(-50%);border:none;background:none;cursor:pointer;color:var(--text-muted);font-size:0.85em;">Hide</button>
+          </div>
+          <button type="submit" class="btn-primary">Add Account</button>
+        </form>
+      </div>
+    </details>
+  </div>`;
+}
+
+export const serviceName = 'twilio';
+export const displayName = 'Twilio';

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -19,7 +19,7 @@ import { executeQueueEntry } from '../lib/queueExecutor.js';
 import { notifyAgentQueueWarning } from '../lib/agentNotifier.js';
 
 // Valid services that support write operations
-const VALID_SERVICES = ['github', 'bluesky', 'reddit', 'mastodon', 'calendar', 'google_calendar', 'youtube', 'linkedin', 'jira', 'fitbit', 'homeassistant'];
+const VALID_SERVICES = ['github', 'bluesky', 'reddit', 'mastodon', 'calendar', 'google_calendar', 'youtube', 'linkedin', 'jira', 'fitbit', 'homeassistant', 'twilio'];
 
 // Valid HTTP methods for write operations
 const VALID_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];

--- a/tests/twilio.test.js
+++ b/tests/twilio.test.js
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/lib/db.js', () => ({
+  getAccountCredentials: jest.fn()
+}));
+
+const { getAccountCredentials } = await import('../src/lib/db.js');
+const { serviceInfo, readService } = await import('../src/routes/twilio.js');
+
+describe('twilio service', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    delete globalThis.fetch;
+  });
+
+  describe('serviceInfo', () => {
+    it('should have correct structure', () => {
+      expect(serviceInfo.key).toBe('twilio');
+      expect(serviceInfo.authType).toBe('basic');
+      expect(serviceInfo.authMethods).toEqual(['basic']);
+      expect(serviceInfo.name).toBe('Twilio');
+      expect(serviceInfo.examples).toBeDefined();
+      expect(serviceInfo.examples.length).toBeGreaterThan(0);
+      expect(serviceInfo.writeGuidelines).toBeDefined();
+      expect(serviceInfo.writeGuidelines.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('readService', () => {
+    it('should return 401 when credentials are missing', async () => {
+      getAccountCredentials.mockReturnValue(null);
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+      expect(result.data.error).toContain('not configured');
+    });
+
+    it('should return 401 when accountSid is missing', async () => {
+      getAccountCredentials.mockReturnValue({ authToken: 'token123' });
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+    });
+
+    it('should return 401 when authToken is missing', async () => {
+      getAccountCredentials.mockReturnValue({ accountSid: 'AC123' });
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+    });
+
+    it('should fetch messages with basic auth', async () => {
+      getAccountCredentials.mockReturnValue({
+        accountSid: 'AC123',
+        authToken: 'token456'
+      });
+
+      const mockMessages = {
+        messages: [{ sid: 'SM1', body: 'Hello' }]
+      };
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => mockMessages
+      });
+
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual(mockMessages);
+
+      const fetchCall = globalThis.fetch.mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json');
+      const expectedAuth = Buffer.from('AC123:token456').toString('base64');
+      expect(fetchCall[1].headers['Authorization']).toBe(`Basic ${expectedAuth}`);
+    });
+
+    it('should pass query parameters', async () => {
+      getAccountCredentials.mockReturnValue({
+        accountSid: 'AC123',
+        authToken: 'token456'
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ messages: [] })
+      });
+
+      await readService('test', 'Messages.json', { query: { PageSize: '10' } });
+
+      const fetchCall = globalThis.fetch.mock.calls[0];
+      expect(fetchCall[0]).toContain('PageSize=10');
+    });
+
+    it('should handle API errors', async () => {
+      getAccountCredentials.mockReturnValue({
+        accountSid: 'AC123',
+        authToken: 'badtoken'
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({ code: 20003, message: 'Authenticate' })
+      });
+
+      const result = await readService('test', 'Messages.json');
+      expect(result.status).toBe(401);
+      expect(result.data.code).toBe(20003);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add Twilio as a supported service in agentgate for SMS messaging via the human-in-the-loop approval system.

Closes #320

## Changes

### New files
- `src/routes/twilio.js` — Express router with serviceInfo, readService, and GET routes
- `src/routes/ui/twilio.js` — UI module with setup/delete forms and renderCard
- `public/icons/twilio.svg` — Twilio icon
- `tests/twilio.test.js` — Jest tests for readService

### Modified files
- `src/index.js` — Mount twilio routes
- `src/lib/serviceRegistry.js` — Register twilio service + messaging category
- `src/lib/queueExecutor.js` — Add twilio to SERVICE_URLS, getAccessToken, buildUrl, buildHeaders (Basic auth)
- `src/services/queueService.js` — Add twilio to VALID_SERVICES
- `src/routes/ui/services.js` — Add twilio UI module + catalog entry
- `src/routes/ui/service-detail.js` — Add twilio form fields + icon

## Implementation Details

- Uses Basic auth: `Authorization: Basic base64(accountSid:authToken)`
- API paths include Account SID: `/Accounts/{SID}/Messages.json`
- Credentials stored as `{ accountSid, authToken }`
- Follows existing patterns (Jira for Basic auth, Home Assistant for structure)
- All lint and tests pass ✅