### PR TITLE
fix: include views/ in npm package files (#327)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "src/",
-    "public/"
+    "public/",
+    "views/"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

`npx agentgate` is broken — EJS templates are not included in the npm package.

```
Error: Failed to lookup view "pages/setup-password" in views directory
```

## Cause

The `files` field in `package.json` only lists `src/` and `public/`. The `views/` directory (added in PR #272) is missing.

## Fix

Add `"views/"` to the `files` array.

Closes #327