### PR TITLE
fix: add re-authorize button to service detail page (#329)

### DIFF
--- a/src/routes/ui/service-detail.js
+++ b/src/routes/ui/service-detail.js
@@ -70,6 +70,8 @@ router.get('/:id', (req, res) => {
     return { key, masked };
   });
 
+  const retryRoute = getRetryRoute(account.service);
+
   renderPage(res, 'pages/service-detail', {
     title: `${displayName} - ${account.name}`,
     includeSocket: true,
@@ -79,6 +81,7 @@ router.get('/:id', (req, res) => {
     displayName,
     icon,
     credFields,
+    retryRoute,
     escapeHtml,
     renderAvatar
   });
@@ -173,6 +176,21 @@ function renderServiceTypeNotFound(res, serviceType) {
     includeSocket: true,
     message: `The service type "${escapeHtml(serviceType)}" is not available.`
   });
+}
+
+/**
+ * Return the retry-auth route for OAuth services, or null for non-OAuth.
+ */
+function getRetryRoute(serviceName) {
+  const routes = {
+    youtube: '/ui/youtube/retry',
+    google_calendar: '/ui/google/retry',
+    fitbit: '/ui/fitbit/retry',
+    linkedin: '/ui/linkedin/retry',
+    reddit: '/ui/reddit/retry',
+    mastodon: '/ui/mastodon/retry'
+  };
+  return routes[serviceName] || null;
 }
 
 function getServiceIcon(service) {

--- a/views/pages/service-detail.ejs
+++ b/views/pages/service-detail.ejs
@@ -18,6 +18,14 @@
         </div>
       <% }); %>
     <% } %>
+    <% if (retryRoute) { %>
+      <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid rgba(255,255,255,0.06);">
+        <form method="POST" action="<%= retryRoute %>" style="margin:0;">
+          <input type="hidden" name="accountName" value="<%- escapeHtml(account.name) %>" autocomplete="off">
+          <button type="submit" class="btn-sm btn-secondary">Re-authorize</button>
+        </form>
+      </div>
+    <% } %>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

Actually adds the Re-authorize button where users can see it — on the **service detail page** (`service-detail.ejs`).

PR #330 modified `renderCard()` in individual service files, but the current UI uses `renderConfiguredCards()` (services list) and `service-detail.ejs` (detail view), so the button never rendered.

## Changes

**`src/routes/ui/service-detail.js`:**
- Added `getRetryRoute()` — maps OAuth service names to their `/retry` route
- Passes `retryRoute` to the template (null for non-OAuth services)

**`views/pages/service-detail.ejs`:**
- Renders a "Re-authorize" button at the bottom of the Credentials card when `retryRoute` is set
- Uses existing `btn-secondary` styling
- Posts to the service-specific retry route with the account name

## OAuth services covered
YouTube, Google Calendar, Fitbit, LinkedIn, Reddit, Mastodon

## Testing
- ✅ Lint clean
- ✅ All 99 tests pass (8 suites)

Closes #329