### PR TITLE
fix: derive OAuth callback URLs from request headers (#333)

### DIFF
--- a/src/routes/ui/calendar.js
+++ b/src/routes/ui/calendar.js
@@ -1,7 +1,7 @@
 import { setAccountCredentials, deleteAccount, getAccountCredentials } from '../../lib/db.js';
-import { renderErrorPage } from './shared.js';
+import { renderErrorPage, getBaseUrl } from './shared.js';
 
-export function registerRoutes(router, baseUrl) {
+export function registerRoutes(router, _baseUrl) {
   router.post('/google/setup', (req, res) => {
     const { accountName, clientId, clientSecret } = req.body;
     if (!accountName || !clientId || !clientSecret) {
@@ -9,7 +9,7 @@ export function registerRoutes(router, baseUrl) {
     }
     setAccountCredentials('google_calendar', accountName, { clientId, clientSecret });
 
-    const redirectUri = `${baseUrl}/ui/google/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/google/callback`;
     const scope = 'https://www.googleapis.com/auth/calendar.readonly';
     const state = `agentgate_google_${accountName}`;
 
@@ -40,7 +40,7 @@ export function registerRoutes(router, baseUrl) {
     }
 
     try {
-      const redirectUri = `${baseUrl}/ui/google/callback`;
+      const redirectUri = `${getBaseUrl(req)}/ui/google/callback`;
 
       const response = await fetch('https://oauth2.googleapis.com/token', {
         method: 'POST',
@@ -91,7 +91,7 @@ export function registerRoutes(router, baseUrl) {
       return res.status(400).send(renderErrorPage('Retry Error', 'Account credentials not found. Please set up the account again.'));
     }
 
-    const redirectUri = `${baseUrl}/ui/google/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/google/callback`;
     const scope = 'https://www.googleapis.com/auth/calendar.readonly';
     const state = `agentgate_google_${accountName}`;
 

--- a/src/routes/ui/fitbit.js
+++ b/src/routes/ui/fitbit.js
@@ -1,7 +1,7 @@
 import { setAccountCredentials, deleteAccount, getAccountCredentials } from '../../lib/db.js';
-import { renderErrorPage } from './shared.js';
+import { renderErrorPage, getBaseUrl } from './shared.js';
 
-export function registerRoutes(router, baseUrl) {
+export function registerRoutes(router, _baseUrl) {
   router.post('/fitbit/setup', (req, res) => {
     const { accountName, clientId, clientSecret } = req.body;
     if (!accountName || !clientId || !clientSecret) {
@@ -9,7 +9,7 @@ export function registerRoutes(router, baseUrl) {
     }
     setAccountCredentials('fitbit', accountName, { clientId, clientSecret });
 
-    const redirectUri = `${baseUrl}/ui/fitbit/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/fitbit/callback`;
     const scope = 'activity heartrate location nutrition oxygen_saturation profile respiratory_rate settings sleep social temperature weight';
     const state = `agentgate_fitbit_${accountName}`;
 
@@ -39,7 +39,7 @@ export function registerRoutes(router, baseUrl) {
     }
 
     try {
-      const redirectUri = `${baseUrl}/ui/fitbit/callback`;
+      const redirectUri = `${getBaseUrl(req)}/ui/fitbit/callback`;
       const basicAuth = Buffer.from(`${creds.clientId}:${creds.clientSecret}`).toString('base64');
 
       const response = await fetch('https://api.fitbit.com/oauth2/token', {
@@ -91,7 +91,7 @@ export function registerRoutes(router, baseUrl) {
       return res.status(400).send(renderErrorPage('Retry Error', 'Account credentials not found. Please set up the account again.'));
     }
 
-    const redirectUri = `${baseUrl}/ui/fitbit/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/fitbit/callback`;
     const scope = 'activity heartrate location nutrition oxygen_saturation profile respiratory_rate settings sleep social temperature weight';
     const state = `agentgate_fitbit_${accountName}`;
 

--- a/src/routes/ui/linkedin.js
+++ b/src/routes/ui/linkedin.js
@@ -1,7 +1,7 @@
 import { setAccountCredentials, deleteAccount, getAccountCredentials } from '../../lib/db.js';
-import { renderErrorPage } from './shared.js';
+import { renderErrorPage, getBaseUrl } from './shared.js';
 
-export function registerRoutes(router, baseUrl) {
+export function registerRoutes(router, _baseUrl) {
   const DEFAULT_SCOPES = 'openid profile email w_member_social';
 
   router.post('/linkedin/setup', (req, res) => {
@@ -15,7 +15,7 @@ export function registerRoutes(router, baseUrl) {
     
     setAccountCredentials('linkedin', accountName, { clientId, clientSecret, scopes: scopeList });
 
-    const redirectUri = `${baseUrl}/ui/linkedin/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/linkedin/callback`;
     const state = `agentgate_linkedin_${accountName}`;
 
     const authUrl = 'https://www.linkedin.com/oauth/v2/authorization?' +
@@ -44,7 +44,7 @@ export function registerRoutes(router, baseUrl) {
     }
 
     try {
-      const redirectUri = `${baseUrl}/ui/linkedin/callback`;
+      const redirectUri = `${getBaseUrl(req)}/ui/linkedin/callback`;
 
       const response = await fetch('https://www.linkedin.com/oauth/v2/accessToken', {
         method: 'POST',
@@ -94,7 +94,7 @@ export function registerRoutes(router, baseUrl) {
       return res.status(400).send(renderErrorPage('Retry Error', 'Account credentials not found. Please set up the account again.'));
     }
 
-    const redirectUri = `${baseUrl}/ui/linkedin/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/linkedin/callback`;
     const scopeList = creds.scopes || 'openid profile email w_member_social';
     const state = `agentgate_linkedin_${accountName}`;
 

--- a/src/routes/ui/mastodon.js
+++ b/src/routes/ui/mastodon.js
@@ -1,7 +1,7 @@
 import { setAccountCredentials, deleteAccount, getAccountCredentials } from '../../lib/db.js';
-import { renderErrorPage } from './shared.js';
+import { renderErrorPage, getBaseUrl } from './shared.js';
 
-export function registerRoutes(router, baseUrl) {
+export function registerRoutes(router, _baseUrl) {
   const DEFAULT_SCOPES = 'read write:statuses';
 
   // Simple auth: paste an access token directly (no OAuth dance)
@@ -35,9 +35,9 @@ export function registerRoutes(router, baseUrl) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           client_name: 'agentgate',
-          redirect_uris: `${baseUrl}/ui/mastodon/callback`,
+          redirect_uris: `${getBaseUrl(req)}/ui/mastodon/callback`,
           scopes: scopeList,
-          website: baseUrl
+          website: getBaseUrl(req)
         })
       });
 
@@ -56,7 +56,7 @@ export function registerRoutes(router, baseUrl) {
 
       const authUrl = `https://${cleanInstance}/oauth/authorize?` +
         `client_id=${app.client_id}&response_type=code&` +
-        `redirect_uri=${encodeURIComponent(`${baseUrl}/ui/mastodon/callback`)}&` +
+        `redirect_uri=${encodeURIComponent(`${getBaseUrl(req)}/ui/mastodon/callback`)}&` +
         `scope=${encodeURIComponent(scopeList)}&state=${encodeURIComponent(`agentgate_mastodon_${accountName}`)}`;
 
       res.redirect(authUrl);
@@ -91,7 +91,7 @@ export function registerRoutes(router, baseUrl) {
         body: JSON.stringify({
           client_id: creds.clientId,
           client_secret: creds.clientSecret,
-          redirect_uri: `${baseUrl}/ui/mastodon/callback`,
+          redirect_uri: `${getBaseUrl(req)}/ui/mastodon/callback`,
           grant_type: 'authorization_code',
           code,
           scope: scopeList
@@ -134,7 +134,7 @@ export function registerRoutes(router, baseUrl) {
 
     const authUrl = `https://${creds.instance}/oauth/authorize?` +
       `client_id=${creds.clientId}&response_type=code&` +
-      `redirect_uri=${encodeURIComponent(`${baseUrl}/ui/mastodon/callback`)}&` +
+      `redirect_uri=${encodeURIComponent(`${getBaseUrl(req)}/ui/mastodon/callback`)}&` +
       `scope=${encodeURIComponent(scopeList)}&state=${encodeURIComponent(`agentgate_mastodon_${accountName}`)}`;
 
     res.redirect(authUrl);

--- a/src/routes/ui/reddit.js
+++ b/src/routes/ui/reddit.js
@@ -1,7 +1,7 @@
 import { setAccountCredentials, deleteAccount, getAccountCredentials } from '../../lib/db.js';
-import { renderErrorPage } from './shared.js';
+import { renderErrorPage, getBaseUrl } from './shared.js';
 
-export function registerRoutes(router, baseUrl) {
+export function registerRoutes(router, _baseUrl) {
   router.post('/reddit/setup', (req, res) => {
     const { accountName, clientId, clientSecret } = req.body;
     if (!accountName || !clientId || !clientSecret) {
@@ -9,7 +9,7 @@ export function registerRoutes(router, baseUrl) {
     }
     setAccountCredentials('reddit', accountName, { clientId, clientSecret });
 
-    const redirectUri = `${baseUrl}/ui/reddit/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/reddit/callback`;
     const scope = 'read identity';
     const state = `agentgate_reddit_${accountName}`;
 
@@ -40,7 +40,7 @@ export function registerRoutes(router, baseUrl) {
 
     try {
       const basicAuth = Buffer.from(`${creds.clientId}:${creds.clientSecret}`).toString('base64');
-      const redirectUri = `${baseUrl}/ui/reddit/callback`;
+      const redirectUri = `${getBaseUrl(req)}/ui/reddit/callback`;
 
       const response = await fetch('https://www.reddit.com/api/v1/access_token', {
         method: 'POST',
@@ -89,7 +89,7 @@ export function registerRoutes(router, baseUrl) {
       return res.status(400).send(renderErrorPage('Retry Error', 'Account credentials not found. Please set up the account again.'));
     }
 
-    const redirectUri = `${baseUrl}/ui/reddit/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/reddit/callback`;
     const scope = 'read identity';
     const state = `agentgate_reddit_${accountName}`;
 

--- a/src/routes/ui/shared.js
+++ b/src/routes/ui/shared.js
@@ -6,6 +6,17 @@ export const COOKIE_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 1 week
 export const PORT = process.env.PORT || 3050;
 export const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
 
+/**
+ * Derive the base URL from an incoming request.
+ * Priority: BASE_URL env > X-Forwarded-* headers > req.protocol/host
+ */
+export function getBaseUrl(req) {
+  if (process.env.BASE_URL) return process.env.BASE_URL;
+  const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http';
+  const host = req.headers['x-forwarded-host'] || req.headers.host || `localhost:${PORT}`;
+  return `${proto}://${host}`;
+}
+
 // HTML escape helper
 export function escapeHtml(str) {
   if (typeof str !== 'string') str = JSON.stringify(str, null, 2);

--- a/src/routes/ui/youtube.js
+++ b/src/routes/ui/youtube.js
@@ -1,7 +1,7 @@
 import { setAccountCredentials, deleteAccount, getAccountCredentials } from '../../lib/db.js';
-import { renderErrorPage } from './shared.js';
+import { renderErrorPage, getBaseUrl } from './shared.js';
 
-export function registerRoutes(router, baseUrl) {
+export function registerRoutes(router, _baseUrl) {
   router.post('/youtube/setup', (req, res) => {
     const { accountName, clientId, clientSecret } = req.body;
     if (!accountName || !clientId || !clientSecret) {
@@ -9,7 +9,7 @@ export function registerRoutes(router, baseUrl) {
     }
     setAccountCredentials('youtube', accountName, { clientId, clientSecret });
 
-    const redirectUri = `${baseUrl}/ui/youtube/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/youtube/callback`;
     const scope = 'https://www.googleapis.com/auth/youtube.readonly';
     const state = `agentgate_youtube_${accountName}`;
 
@@ -39,7 +39,7 @@ export function registerRoutes(router, baseUrl) {
     }
 
     try {
-      const redirectUri = `${baseUrl}/ui/youtube/callback`;
+      const redirectUri = `${getBaseUrl(req)}/ui/youtube/callback`;
 
       const response = await fetch('https://oauth2.googleapis.com/token', {
         method: 'POST',
@@ -89,7 +89,7 @@ export function registerRoutes(router, baseUrl) {
       return res.status(400).send(renderErrorPage('Retry Error', 'Account credentials not found. Please set up the account again.'));
     }
 
-    const redirectUri = `${baseUrl}/ui/youtube/callback`;
+    const redirectUri = `${getBaseUrl(req)}/ui/youtube/callback`;
     const scope = 'https://www.googleapis.com/auth/youtube.readonly';
     const state = `agentgate_youtube_${accountName}`;
 


### PR DESCRIPTION
## Summary

OAuth callback URLs were hardcoded to the static `baseUrl` computed at startup (defaults to `http://localhost:3050`). When AgentGate runs behind a reverse proxy, Google/Fitbit/etc redirect to localhost instead of the real server.

## Changes

**`src/routes/ui/shared.js`:**
- Added `getBaseUrl(req)` — derives base URL per-request
- Priority: `BASE_URL` env var > `X-Forwarded-Proto`/`X-Forwarded-Host` headers > `req.protocol`/`req.headers.host`

**6 OAuth service files** (youtube, calendar, fitbit, linkedin, reddit, mastodon):
- Import `getBaseUrl` from shared.js
- Replace closure `baseUrl` with `getBaseUrl(req)` in route handlers (setup, callback, retry)
- `renderCard` functions unchanged (display-only, fine with static URL)

## How it works

1. If `BASE_URL` env is set → uses that (explicit config wins)
2. Otherwise reads `X-Forwarded-Proto` and `X-Forwarded-Host` from the proxy
3. Falls back to `req.protocol`/`req.headers.host`

No config needed when behind a standard reverse proxy that sets forwarding headers.

Closes #333

## Testing
- ✅ ESLint: 0 errors
- ✅ All 99 tests pass (8 suites)