### PR TITLE
fix: default to https for non-localhost OAuth callbacks

### DIFF
--- a/src/routes/ui/shared.js
+++ b/src/routes/ui/shared.js
@@ -12,8 +12,9 @@ export const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
  */
 export function getBaseUrl(req) {
   if (process.env.BASE_URL) return process.env.BASE_URL;
-  const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http';
   const host = req.headers['x-forwarded-host'] || req.headers.host || `localhost:${PORT}`;
+  const isLocal = host.startsWith('localhost') || host.startsWith('127.0.0.1');
+  const proto = req.headers['x-forwarded-proto'] || (isLocal ? 'http' : 'https');
   return `${proto}://${host}`;
 }
 


### PR DESCRIPTION
Follow-up to #334. TLS-terminating proxies (Caddy, nginx) connect to the app over plain HTTP, so `req.protocol` returns `http` and `X-Forwarded-Proto` may not be set. This caused OAuth redirects to use `http://agentgate.iot.horse` instead of `https://`.

Fix: if the host is not localhost/127.0.0.1, default proto to `https`. Simple, correct for any production deployment.

1-line change in `getBaseUrl()`.

- ✅ Lint clean
- ✅ All 99 tests pass