### PR TITLE
feat: auto-generate sidecar secret + cache hash lookup (#338)

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -977,18 +977,30 @@ export function hasAdminPassword() {
   return getSetting('admin_password') !== null;
 }
 
-// Sidecar Secret
+// Sidecar Secret (cached — invalidated on set/clear)
+let _cachedSidecarHash = undefined; // undefined = not yet loaded
+
 export async function setSidecarSecret(plaintext) {
   const hash = await bcrypt.hash(plaintext, 10);
   setSetting('sidecar_secret', hash);
+  _cachedSidecarHash = hash;
 }
 
 export function getSidecarSecretHash() {
-  return getSetting('sidecar_secret');
+  if (_cachedSidecarHash === undefined) {
+    _cachedSidecarHash = getSetting('sidecar_secret') || null;
+  }
+  return _cachedSidecarHash;
 }
 
 export function clearSidecarSecret() {
-  return deleteSetting('sidecar_secret');
+  deleteSetting('sidecar_secret');
+  _cachedSidecarHash = null;
+}
+
+// Exported for testing only
+export function _resetSidecarCache() {
+  _cachedSidecarHash = undefined;
 }
 
 // Cookie secret (generated once, persisted)

--- a/src/routes/ui/settings.js
+++ b/src/routes/ui/settings.js
@@ -94,14 +94,13 @@ router.post('/queue/settings/agent-withdraw', (req, res) => {
   res.redirect('/ui');
 });
 
-// Sidecar Secret
-router.post('/sidecar-secret/set', async (req, res) => {
-  const { secret } = req.body;
-  if (!secret || !secret.trim()) {
-    return res.status(400).send('Secret is required');
-  }
-  await setSidecarSecret(secret.trim());
-  res.redirect('/ui/settings');
+// Sidecar Secret — auto-generated, never user-supplied
+router.post('/sidecar-secret/generate', async (req, res) => {
+  const { randomBytes } = await import('crypto');
+  const secret = randomBytes(32).toString('hex'); // 64-char hex, 256 bits
+  await setSidecarSecret(secret);
+  // Return the plaintext once — after this it can never be retrieved
+  res.json({ secret });
 });
 
 router.post('/sidecar-secret/clear', (req, res) => {

--- a/views/pages/settings.ejs
+++ b/views/pages/settings.ejs
@@ -73,19 +73,45 @@
   </h3>
   <% if (sidecarSecretConfigured) { %>
     <p class="help">A sidecar secret is configured. All API requests must include the <code>X-Sidecar-Secret</code> header.</p>
+    <div id="sidecar-secret-display" style="display:none; margin: 12px 0;">
+      <p class="help" style="color: var(--warning-color, #f0ad4e); font-weight: bold;">⚠️ Copy this secret now — it will not be shown again.</p>
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <code id="sidecar-secret-value" style="background: var(--bg-secondary, #1a1a2e); padding: 8px 12px; border-radius: 4px; word-break: break-all; flex: 1;"></code>
+        <button type="button" class="btn-primary btn-sm" onclick="navigator.clipboard.writeText(document.getElementById('sidecar-secret-value').textContent).then(() => this.textContent = 'Copied!').catch(() => {})">Copy</button>
+      </div>
+    </div>
     <div class="flex-center gap-12 flex-wrap">
+      <button type="button" class="btn-primary btn-sm" onclick="generateSidecarSecret()">Regenerate</button>
       <form method="POST" action="/ui/sidecar-secret/clear" style="display:inline">
         <button type="submit" class="btn-danger btn-sm">Clear Secret</button>
       </form>
     </div>
   <% } else { %>
-    <p class="help">Set a shared secret that sidecar proxies must include on API requests. Optional — leave unconfigured to allow all API requests.</p>
-    <form method="POST" action="/ui/sidecar-secret/set">
-      <label>Secret</label>
-      <input type="password" name="secret" placeholder="Enter sidecar secret" required autocomplete="off">
-      <button type="submit" class="btn-primary">Set Secret</button>
-    </form>
+    <p class="help">Enable a sidecar secret to require an <code>X-Sidecar-Secret</code> header on all API requests. A strong secret is auto-generated for you.</p>
+    <div id="sidecar-secret-display" style="display:none; margin: 12px 0;">
+      <p class="help" style="color: var(--warning-color, #f0ad4e); font-weight: bold;">⚠️ Copy this secret now — it will not be shown again.</p>
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <code id="sidecar-secret-value" style="background: var(--bg-secondary, #1a1a2e); padding: 8px 12px; border-radius: 4px; word-break: break-all; flex: 1;"></code>
+        <button type="button" class="btn-primary btn-sm" onclick="navigator.clipboard.writeText(document.getElementById('sidecar-secret-value').textContent).then(() => this.textContent = 'Copied!').catch(() => {})">Copy</button>
+      </div>
+    </div>
+    <button type="button" class="btn-primary" onclick="generateSidecarSecret()">Enable Sidecar Secret</button>
   <% } %>
+  <script>
+    async function generateSidecarSecret() {
+      if (!confirm('Generate a new sidecar secret? Any existing secret will be replaced.')) return;
+      try {
+        const res = await fetch('/ui/sidecar-secret/generate', { method: 'POST' });
+        const data = await res.json();
+        const display = document.getElementById('sidecar-secret-display');
+        const value = document.getElementById('sidecar-secret-value');
+        value.textContent = data.secret;
+        display.style.display = 'block';
+      } catch (e) {
+        alert('Failed to generate secret: ' + e.message);
+      }
+    }
+  </script>
 </div>
 
 <!-- hsync Remote Access -->


### PR DESCRIPTION
Closes #338

## Changes

### 1. Auto-generate secret (no manual input)
- Removed manual text input from settings UI
- "Enable Sidecar Secret" button generates 256-bit random secret via `crypto.randomBytes(32)`
- Secret displayed **once** with copy button, never retrievable again
- Regenerate button for existing secrets
- Same UX pattern as API key creation

### 2. Cache `getSidecarSecretHash()`
- In-memory cache avoids SQLite read on every `/api/*` request
- Cache invalidated immediately on `setSidecarSecret()` and `clearSidecarSecret()`
- No stale data possible — simpler than TTL
- `_resetSidecarCache()` exported for testing

## Testing

```
npm test: 164 passed, 5 skipped
npm run lint: clean
```

Reviewer: @luthien-m